### PR TITLE
Fix: Swap button positions and refine expansion animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,6 +566,13 @@
                 <i class="fas fa-times-circle main-search-clear" id="clearSearch"></i>
             </div>
             
+            <!-- Expand/Collapse All Button -->
+            <div class="text-center mt-4 mb-4">
+                <button id="expandCollapseBtn" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out">
+                    Expand All
+                </button>
+            </div>
+
             <div class="flex items-center justify-between">
                 <div class="text-lg font-medium">
                     <span id="valuesCount" class="text-purple-600"></span> Values
@@ -573,13 +580,6 @@
                 <button id="toggleFilters" class="text-purple-600 hover:text-purple-800 focus:outline-none text-sm">
                     <span id="toggleFiltersText">Show Filters</span>
                     <i id="toggleFiltersIcon" class="fas fa-chevron-down ml-1"></i>
-                </button>
-            </div>
-
-            <!-- Expand/Collapse All Button -->
-            <div class="text-center mt-4 mb-4">
-                <button id="expandCollapseBtn" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out">
-                    Expand All
                 </button>
             </div>
         </header>

--- a/style.css
+++ b/style.css
@@ -190,7 +190,7 @@ button, input, select {
     overflow: hidden;
     max-height: 0;
     opacity: 0; /* Added from index.html */
-    transition: max-height 0.5s ease, opacity 0.3s ease 0.1s; /* Merged from index.html */
+    transition: max-height 0.7s cubic-bezier(0.645, 0.045, 0.355, 1), opacity 0.5s cubic-bezier(0.645, 0.045, 0.355, 1) 0.1s; /* Merged from index.html */
 }
 
 .value-card.expanded .value-card-content { /* Renamed from .expandable-content */
@@ -219,7 +219,7 @@ button, input, select {
 .value-card.expanded {
     background: #fffefc;
     border: 1px solid #E2D6C7;
-    animation: bounceIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); /* Added animation */
+    /* animation: bounceIn 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); */ /* Added animation */
 }
 
 /* Active Filters Count */


### PR DESCRIPTION
I've swapped the visual positions of the "Expand All" and "Show Filters" buttons in the HTML structure to match your request.

I also refined the card expansion animation:
- I removed the previous `bounceIn` keyframe animation that caused a "jolt".
- I adjusted the CSS transition for `.value-card-content` to use a `cubic-bezier` timing function and modified duration (0.7s for max-height, 0.5s for opacity) to create a smoother "soft float" effect.

I verified that the "Expand All" button's JavaScript logic correctly toggles the `expanded` class on all value cards, and the updated CSS ensures they are displayed with the new smoother animation. This should address your concern about the "Expand All" functionality and animation.