### PR TITLE
Fix: Adjust letter navigation styling and hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,45 +314,6 @@
             margin-left: 0.5rem;
         }
         
-        /* Alphabetical navigation */
-        .alpha-nav {
-            position: fixed;
-            left: 20px;
-            top: 50%;
-            transform: translateY(-50%);
-            background-color: var(--card-bg);
-            border-radius: 20px;
-            padding: 8px 4px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
-            display: flex;
-            flex-direction: column;
-            z-index: 40;
-        }
-        
-        .alpha-nav a {
-            font-size: 0.75rem;
-            padding: 4px 8px;
-            color: var(--accent-primary);
-            text-align: center;
-            border-radius: 4px;
-            transition: all 0.2s;
-            text-decoration: none;
-        }
-        
-        .alpha-nav a:hover, 
-        .alpha-nav a.active {
-            background-color: var(--accent-primary);
-            color: var(--card-bg);
-        }
-        
-        .alpha-nav .nav-divider {
-            height: 1px;
-            background-color: rgba(165, 136, 172, 0.2);
-            margin: 4px 0;
-            width: 80%;
-            align-self: center;
-        }
-        
         /* Back to top button */
         .back-to-top {
             position: fixed;

--- a/style.css
+++ b/style.css
@@ -134,6 +134,8 @@ button, input, select {
     padding: 0.5rem;
     border-radius: 10px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
 }
 
 #alphaNav a {
@@ -143,11 +145,23 @@ button, input, select {
     font-weight: 600;
     color: #6B46C1;
     text-decoration: none;
-    font-size: 0.9rem;
+    font-size: 0.75rem;
+    padding: 3px 6px;
+    transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 
 #alphaNav a:hover {
-    color: #553C9A;
+    transform: scale(1.15);
+    background-color: var(--accent-primary); /* From original .alpha-nav a:hover in index.html */
+    color: var(--card-bg); /* From original .alpha-nav a:hover in index.html */
+}
+
+#alphaNav .nav-divider {
+    height: 1px;
+    background-color: rgba(165, 136, 172, 0.2); /* Copied from index.html .alpha-nav .nav-divider */
+    margin: 4px 0; /* Copied from index.html .alpha-nav .nav-divider */
+    width: 80%; /* Copied from index.html .alpha-nav .nav-divider */
+    align-self: center; /* Copied from index.html .alpha-nav .nav-divider */
 }
 
 /* Category Label */


### PR DESCRIPTION
Consolidated CSS for the alphabetical navigation into style.css, removing conflicting embedded styles from index.html.

Key changes:
- Set the default font size for navigation links to 0.75rem and padding to 3px 6px, making them smaller as requested.
- Implemented a hover effect where letters scale to 1.15 times their original size with a smooth transition. Existing hover color changes are preserved.
- Verified that the navigation links correctly point to their corresponding page sections.

The navigation remains hidden on screens narrower than 768px as per existing responsive design.