### PR TITLE
Fix: Make alphabet nav responsive and remove Expand All button

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,11 +479,6 @@
         }
         
         /* Responsive styles */
-        @media (max-width: 768px) {
-            .alpha-nav {
-                display: none;
-            }
-        }
     </style>
 </head>
 <body>
@@ -527,12 +522,6 @@
                 <i class="fas fa-times-circle main-search-clear" id="clearSearch"></i>
             </div>
             
-            <!-- Expand/Collapse All Button -->
-            <div class="text-center mt-4 mb-4">
-                <button id="expandCollapseBtn" class="bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded-lg shadow-md transition duration-150 ease-in-out">
-                    Expand All
-                </button>
-            </div>
 
             <div class="flex items-center justify-between">
                 <div class="text-lg font-medium">

--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ const filterState = {
 
 let searchInput, mainSearchInput, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList, 
     matchAll, matchAny, toggleSlide, activeFilters, clearFilters, filterCount, 
-    toggleFilters, filtersContainer, valuesCount, alphaNav, backToTop, languageToggle, expandCollapseBtn;
+    toggleFilters, filtersContainer, valuesCount, alphaNav, backToTop, languageToggle;
 
 // --- Initialize on DOM Content Loaded ---
 document.addEventListener('DOMContentLoaded', async function() {
@@ -48,7 +48,6 @@ function getDOMElements() {
     alphaNav = document.getElementById('alphaNav');
     backToTop = document.getElementById('backToTop');
     languageToggle = document.getElementById('languageToggle');
-    expandCollapseBtn = document.getElementById('expandCollapseBtn');
 }
 
 // --- Fetch Values ---
@@ -71,33 +70,6 @@ function setupUI() {
     setupAlphaNav();
     setupBackToTop();
     setupLanguageToggle();
-    setupExpandCollapseControls();
-}
-
-function setupExpandCollapseControls() {
-    if (!expandCollapseBtn) return;
-
-    expandCollapseBtn.addEventListener('click', () => {
-        const isExpanding = expandCollapseBtn.textContent.includes('Expand All');
-        const allCards = document.querySelectorAll('.value-card');
-
-        allCards.forEach(card => {
-            const toggleButton = card.querySelector('.value-card-toggle');
-            if (isExpanding) {
-                card.classList.add('expanded');
-                if (toggleButton) {
-                    toggleButton.innerHTML = 'Read less <i class="fas fa-chevron-up"></i>';
-                }
-            } else {
-                card.classList.remove('expanded');
-                if (toggleButton) {
-                    toggleButton.innerHTML = 'Read more <i class="fas fa-chevron-down"></i>';
-                }
-            }
-        });
-
-        expandCollapseBtn.textContent = isExpanding ? 'Collapse All' : 'Expand All';
-    });
 }
 
 function setupSearch() {
@@ -197,31 +169,6 @@ function displayValues(valuesToDisplay) {
     });
 
     setupExpandCollapseLogic();
-    updateGlobalExpandCollapseButtonState(); // Call after initial display
-}
-
-function updateGlobalExpandCollapseButtonState() {
-    if (!expandCollapseBtn) return;
-
-    const allCards = document.querySelectorAll('.value-card');
-    if (allCards.length === 0) {
-        expandCollapseBtn.textContent = 'Expand All';
-        // expandCollapseBtn.disabled = true; // Consider disabling if no cards
-        return;
-    }
-    // expandCollapseBtn.disabled = false; // Ensure enabled if cards exist
-
-    const allExpanded = Array.from(allCards).every(card => card.classList.contains('expanded'));
-    const allCollapsed = Array.from(allCards).every(card => !card.classList.contains('expanded'));
-
-    if (allExpanded) {
-        expandCollapseBtn.textContent = 'Collapse All';
-    } else if (allCollapsed) {
-        expandCollapseBtn.textContent = 'Expand All';
-    } else {
-        // Mixed state, default to "Expand All" as per refined instructions
-        expandCollapseBtn.textContent = 'Expand All';
-    }
 }
 
 function setupExpandCollapseLogic() {
@@ -233,7 +180,6 @@ function setupExpandCollapseLogic() {
             card.classList.toggle('expanded');
             const isExpanded = card.classList.contains('expanded');
             toggle.innerHTML = isExpanded ? 'Read less <i class="fas fa-chevron-up"></i>' : 'Read more <i class="fas fa-chevron-down"></i>';
-            updateGlobalExpandCollapseButtonState(); // Call after individual toggle
         });
     });
 

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@ body {
     color: #333;
     margin: 0;
     padding: 0;
+    padding-left: 50px; /* Add padding to the left of the body */
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -130,12 +131,14 @@ button, input, select {
     left: 10px;
     top: 50%;
     transform: translateY(-50%);
-    background: rgba(255, 255, 255, 0.9);
+    background-color: var(--filter-bg); /* Add a background color */
     padding: 0.5rem;
     border-radius: 10px;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
+    width: 40px; /* Define a fixed width */
+    z-index: 100; /* Ensure it's above other content if not already set high enough */
 }
 
 #alphaNav a {


### PR DESCRIPTION
- Modified CSS for the alphabet navigation (`#alphaNav`):
  - Removed media query that hid it on small screens.
  - Set a fixed width and background color.
  - Added `padding-left` to the `body` to prevent content overlap.
- Removed the "Expand All" button:
  - Deleted the button HTML from `index.html`.
  - Removed associated JavaScript variables, functions, and event listeners from `script.js`.

These changes ensure the alphabet navigation is always visible and correctly positioned without overlapping content, and remove a non-functional UI element.