### PR TITLE
Fix: Ensure alphabet navigation is always fully visible

### DIFF
--- a/style.css
+++ b/style.css
@@ -139,6 +139,8 @@ button, input, select {
     flex-direction: column;
     width: 40px; /* Define a fixed width */
     z-index: 100; /* Ensure it's above other content if not already set high enough */
+    max-height: 90vh;
+    overflow-y: auto;
 }
 
 #alphaNav a {


### PR DESCRIPTION
The alphabet navigation bar (#alphaNav) has been adjusted to ensure all letters (A-Z) remain completely visible and accessible, regardless of window size or scroll placement.

Key changes:
- Added `max-height: 90vh;` to the `#alphaNav` CSS rule. This prevents the navigation bar from exceeding 90% of the viewport height.
- Added `overflow-y: auto;` to the `#alphaNav` CSS rule. This enables a vertical scrollbar within the navigation bar if its content (the list of letters) is taller than the `max-height`, ensuring all letters can be reached even on shorter screens.

The existing `position: fixed;`, `z-index`, and body padding were verified to be correctly implemented for maintaining the navigation's fixed placement and preventing content overlap.