### PR TITLE
feat: Make alphabet navigation responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -1672,6 +1672,19 @@
         let searchInput, mainSearchInput, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList, 
             matchAll, matchAny, toggleSlide, activeFilters, clearFilters, filterCount, 
             toggleFilters, filtersContainer, valuesCount, alphaNav, backToTop, languageToggle;
+
+        // Function to adjust body padding based on alphaNav width
+        function adjustBodyPadding() {
+            const alphaNavElement = document.getElementById('alphaNav');
+            if (alphaNavElement) {
+                const alphaNavWidth = alphaNavElement.offsetWidth;
+                document.body.style.paddingLeft = alphaNavWidth + 10 + 'px';
+            }
+        }
+
+        // Adjust padding on DOMContentLoaded and window resize
+        document.addEventListener('DOMContentLoaded', adjustBodyPadding);
+        window.addEventListener('resize', adjustBodyPadding);
             
         // Wait for DOM to be fully loaded
         document.addEventListener('DOMContentLoaded', function() {

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ body {
     color: #333;
     margin: 0;
     padding: 0;
-    padding-left: 50px; /* Add padding to the left of the body */
+    /* padding-left: 50px; */ /* Add padding to the left of the body - Now handled by JS */
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -137,7 +137,9 @@ button, input, select {
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
     display: flex;
     flex-direction: column;
-    width: 40px; /* Define a fixed width */
+    align-items: center; /* Center items horizontally now that width is flexible */
+    max-width: 45px;
+    min-width: 20px;
     z-index: 100; /* Ensure it's above other content if not already set high enough */
     max-height: 90vh;
     overflow-y: auto;
@@ -148,10 +150,11 @@ button, input, select {
     margin: 0.3rem 0;
     text-align: center;
     font-weight: 600;
-    color: #6B46C1;
+    color: var(--accent-primary);
     text-decoration: none;
-    font-size: 0.75rem;
-    padding: 3px 6px;
+    font-size: 1.8vh; /* Responsive font size */
+    padding: 0.2vh 0.1vw; /* Responsive padding */
+    line-height: 1.2; /* Added line-height */
     transition: transform 0.2s ease, background-color 0.2s ease, color 0.2s ease;
 }
 


### PR DESCRIPTION
The alphabet navigation bar on the left side of the page has been updated to be responsive to window/viewport size.

Key changes:
- Styles for the alpha-nav (`#alphaNav`) were confirmed to be primarily in `style.css`. The `color` property for `#alphaNav a` was updated to use `var(--accent-primary)` for theme consistency.
- CSS for `#alphaNav` and its children (`#alphaNav a`) in `style.css` was modified:
    - Removed fixed width from `#alphaNav` and introduced `min-width` and `max-width`.
    - Implemented responsive `font-size` and `padding` for `#alphaNav a` using `vh` and `vw` units, allowing the text to scale with viewport height.
    - Adjusted `line-height` for better text spacing.
- Added JavaScript to the inline script in `index.html` to dynamically calculate the width of `#alphaNav` and adjust the `padding-left` of the `body` element accordingly. This ensures the main content doesn't overlap with the navigation bar. The static `padding-left` on `body` in `style.css` was removed.

This ensures that all letters A-Z in the alphabet navigation should remain visible at all times, regardless of screen size, by shrinking or growing as needed.