### PR TITLE
Fix zero count display and HTML script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
 
   gtag('config', 'G-LHRZ1LEG85');
 </script>
-</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Howdy Human Dictionary of Values</title>

--- a/script.js
+++ b/script.js
@@ -268,7 +268,7 @@ function setupLanguageToggle() {
 // Update values count display
 function updateValuesCount(count) {
     if (valuesCount) {
-        valuesCount.textContent = count || values.length;
+        valuesCount.textContent = typeof count === 'number' ? count : values.length;
     }
 }
 


### PR DESCRIPTION
## Summary
- fix values counter to show 0 results instead of defaulting to total
- remove stray closing script tag in index.html head

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e25a4e088322be391b84bc801737