### PR TITLE
feat: expand filters by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ for hosting my domain <br>
 ## Usage
 ### Values Dictionary
 - Use the search bar to find specific values <br>
-- Click "Show Filters" to access advanced filtering options <br>
+- Filters are visible by default; click "Hide Filters" to collapse the filter section <br>
 - Apply filters to narrow down the values list: <br>
         - Select categories (Personal, Interpersonal, Social) <br>
-        - Choose specific action verbs (tags) <br> 
+        - Choose specific action verbs (tags) <br>
         - Select between matching ALL or ANY tags <br>
 - Click on tags to see related values <br>
 - Explore connections between values through the related values section <br>

--- a/index.html
+++ b/index.html
@@ -63,14 +63,14 @@
                     <span id="valuesCount" class="text-purple-600"></span> Values
                 </div>
                 <button id="toggleFilters" class="text-purple-600 hover:text-purple-800 focus:outline-none text-sm">
-                    <span id="toggleFiltersText">Show Filters</span>
-                    <i id="toggleFiltersIcon" class="fas fa-chevron-down ml-1"></i>
+                    <span id="toggleFiltersText">Hide Filters</span>
+                    <i id="toggleFiltersIcon" class="fas fa-chevron-up ml-1"></i>
                 </button>
             </div>
         </header>
 
         <!-- Advanced Filters Section -->
-        <div id="filtersContainer" class="filters-container mb-6 p-4 collapsed">
+        <div id="filtersContainer" class="filters-container mb-6 p-4">
             <!-- Match Type Toggle -->
             <div class="flex justify-between items-center mb-4 pb-2 border-b border-gray-200">
                 <div class="flex items-center">

--- a/script.js
+++ b/script.js
@@ -274,15 +274,18 @@ function updateValuesCount(count) {
 
 // Setup filter toggle button
 function setupFilterToggle() {
-    toggleFilters.addEventListener('click', () => {
-        filtersContainer.classList.toggle('collapsed');
+    const updateToggle = () => {
         const isCollapsed = filtersContainer.classList.contains('collapsed');
-
-        // Update text and icon
         document.getElementById('toggleFiltersText').textContent = isCollapsed ? 'Show Filters' : 'Hide Filters';
         const icon = document.getElementById('toggleFiltersIcon');
-        icon.classList.remove(isCollapsed ? 'fa-chevron-up' : 'fa-chevron-down');
-        icon.classList.add(isCollapsed ? 'fa-chevron-down' : 'fa-chevron-up');
+        icon.classList.toggle('fa-chevron-down', isCollapsed);
+        icon.classList.toggle('fa-chevron-up', !isCollapsed);
+    };
+
+    updateToggle();
+    toggleFilters.addEventListener('click', () => {
+        filtersContainer.classList.toggle('collapsed');
+        updateToggle();
     });
 }
 


### PR DESCRIPTION
## Summary
- expand filters by default and allow collapsing via Hide Filters toggle
- refresh README instructions for filter toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ac7d7a50c8322a5d6a13ab3bd4f64