### PR TITLE
Refine site color palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
     --text-callout: #FFFFFF;
     --text-primary: #2E2E2E;
     --text-secondary: #666666;
-    --primary-coral: #FF5A5F;
+    --primary-coral: #BA68C8; /* Updated primary accent to purple */
     --primary-aqua: #3DDCC7;
     --tertiary-gold: #FBC02D;
     --support-purple: #A8B8C8;
@@ -19,10 +19,10 @@
     --accent-primary: var(--primary-coral);
     --accent-secondary: var(--primary-aqua);
     --card-border: var(--support-purple);
-    --section-label: var(--accent-secondary);
-    --header-text: var(--accent-primary);
+    --section-label: #0A3E93; /* Section headings */
+    --header-text: #0A3E93; /* General headings */
     --dark-text: var(--text-secondary);
-    --btn-hover: #E04B50; /* Darker coral */
+    --btn-hover: #9C27B0; /* Darker purple */
     --filter-bg: #EEF0FF; /* Slightly darker than background */
     --tag-bg: #E8ECFF; /* Pale lavender for tags */
 }
@@ -152,7 +152,7 @@ h1, h2, h3, h4, h5, h6 {
 .main-search-input:focus {
     outline: none;
     border-color: var(--accent-primary);
-    box-shadow: 0 0 0 5px rgba(255, 90, 95, 0.2);
+    box-shadow: 0 0 0 5px rgba(186, 104, 200, 0.2);
 }
 
 .main-search-icon {
@@ -215,11 +215,11 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .shared-tag {
-    background-color: rgba(255, 90, 95, 0.1);
+    background-color: rgba(186, 104, 200, 0.1);
     color: var(--accent-primary);
     padding: 0.125rem 0.375rem;
     border-radius: 4px;
-    border: 1px solid rgba(255, 90, 95, 0.3);
+    border: 1px solid rgba(186, 104, 200, 0.3);
 }
 
 .related-tooltip {
@@ -332,7 +332,7 @@ h1, h2, h3, h4, h5, h6 {
 
 .alpha-nav .nav-divider {
     height: 1px;
-    background-color: rgba(255, 90, 95, 0.2);
+    background-color: rgba(186, 104, 200, 0.2);
     margin: 4px 0;
     width: 80%;
     align-self: center;
@@ -410,7 +410,7 @@ h1, h2, h3, h4, h5, h6 {
     justify-content: center;
     padding: 4px 0;
     margin-top: 8px;
-    border-top: 1px solid rgba(255, 90, 95, 0.1);
+    border-top: 1px solid rgba(186, 104, 200, 0.1);
 }
 
 .value-card-toggle i {
@@ -433,7 +433,7 @@ h1, h2, h3, h4, h5, h6 {
     font-weight: 600;
     margin-bottom: 0.75rem;
     padding-bottom: 0.5rem;
-    border-bottom: 1px solid rgba(61, 220, 199, 0.2);
+    border-bottom: 1px solid rgba(10, 62, 147, 0.2);
 }
 
 .section-label i {
@@ -445,7 +445,7 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: 40px;
     padding: 20px 0;
     text-align: center;
-    border-top: 1px solid rgba(255, 90, 95, 0.2);
+    border-top: 1px solid rgba(186, 104, 200, 0.2);
 }
 
 .footer a {
@@ -500,7 +500,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .status-error {
-    background-color: rgba(255, 90, 95, 0.1);
+    background-color: rgba(186, 104, 200, 0.1);
     color: var(--accent-primary);
     border: 1px solid var(--accent-primary);
 }


### PR DESCRIPTION
## Summary
- switch primary accent from coral to purple for interactive elements
- replace red/orange headings with blue tone
- adjust section borders to match new colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbe1d021483229a420e1cbf7c0e8f