### PR TITLE
feat: add expandable filters for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@
                     <div id="categoryFilters" class="space-y-2">
                         <!-- Categories will be added here by JavaScript -->
                     </div>
+                    <button class="show-more-btn">Show More</button>
                 </div>
                 
                 <!-- Column 2: Tags/Verbs -->
@@ -111,6 +112,7 @@
                     <div id="tagFilters" class="space-y-1">
                         <!-- Tags will be added here by JavaScript -->
                     </div>
+                    <button class="show-more-btn">Show More</button>
                 </div>
                 
                 <!-- Column 3: Active Filters -->

--- a/script.js
+++ b/script.js
@@ -316,6 +316,23 @@ function setupMatchTypeToggle() {
     });
 }
 
+// Setup show more/less buttons for filter columns
+function setupFilterExpanders() {
+    document.querySelectorAll('.filter-column').forEach(column => {
+        const button = column.querySelector('.show-more-btn');
+        if (!button) return;
+
+        const isOverflowing = column.scrollHeight > column.clientHeight;
+        button.style.display = isOverflowing ? 'block' : 'none';
+        button.textContent = column.classList.contains('expanded') ? 'Show Less' : 'Show More';
+
+        button.onclick = () => {
+            column.classList.toggle('expanded');
+            button.textContent = column.classList.contains('expanded') ? 'Show Less' : 'Show More';
+        };
+    });
+}
+
 // Clear all filters
 function clearAllFilters() {
     // Reset filter state
@@ -531,6 +548,7 @@ function initializeValuesDictionary() {
         // Initial display of values
         console.log("Displaying values...");
         filterValues();
+        setupFilterExpanders();
 
     } catch (error) {
         console.error("Error initializing dictionary:", error);

--- a/style.css
+++ b/style.css
@@ -108,6 +108,20 @@ button, .value-card-toggle, .status-action-button {
     box-shadow: 0 1px 5px rgba(0, 0, 0, 0.08);
 }
 
+.filter-column.expanded {
+    max-height: none;
+    overflow-y: visible;
+}
+
+.show-more-btn {
+    display: none;
+    width: 100%;
+    margin-top: 0.5rem;
+    color: var(--accent-primary);
+    font-size: 0.875rem;
+    text-align: center;
+}
+
 .filter-column::-webkit-scrollbar {
     width: 6px;
 }


### PR DESCRIPTION
## Summary
- add "Show More" buttons to category and verb filters
- implement JS to expand/collapse overflowing filter columns
- style new expander and expanded states

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68aec221c00083228239dab5772416b8