### PR TITLE
Adjust verbs filter heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
                 
                 <!-- Column 2: Tags/Verbs -->
                 <div class="filter-column p-2 rounded-md">
-                    <div class="filter-header">Action Verbs</div>
+                    <div class="filter-header">Verbs <span class="filter-caption">tags</span></div>
                     <div id="tagFilters" class="space-y-1">
                         <!-- Tags will be added here by JavaScript -->
                     </div>

--- a/style.css
+++ b/style.css
@@ -152,6 +152,13 @@ button, .value-card-toggle, .status-action-button {
     font-size: 1.25rem;
 }
 
+.filter-caption {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-left: 0.25rem;
+    font-weight: 400;
+}
+
 /* Value example styles */
 .value-example {
     background-color: var(--tag-bg);


### PR DESCRIPTION
## Summary
- Rename "Action Verbs" filter column to "Verbs" with a subtle "tags" caption
- Add supporting CSS for caption styling

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b15be6879c8322bb0c262e4561b716