### PR TITLE
Center alphabetical navigation letters

### DIFF
--- a/style.css
+++ b/style.css
@@ -366,6 +366,7 @@ button, .value-card-toggle, .status-action-button {
     top: 4.5rem;
     z-index: 40;
     display: flex;
+    align-items: center;
     overflow-x: auto;
     white-space: nowrap;
     background-color: var(--card-bg);


### PR DESCRIPTION
## Summary
- Center letters in alphabetical navigation bar to remove extra vertical space

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e966c0a08322b3336c7293b178d4