### PR TITLE
Align alphabetical navigation with search bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,7 +179,7 @@ button, .value-card-toggle, .status-action-button {
     position: sticky;
     top: 0;
     z-index: 50;
-    margin-bottom: 1.5rem;
+    margin-bottom: 0.5rem;
     background-color: var(--bg-main);
 }
 
@@ -363,7 +363,7 @@ button, .value-card-toggle, .status-action-button {
 /* Horizontal alphabetical navigation */
 .alpha-nav-horizontal {
     position: sticky;
-    top: 4.5rem;
+    top: 3.5rem;
     z-index: 40;
     display: flex;
     overflow-x: auto;


### PR DESCRIPTION
## Summary
- Reduce margin below main search bar to tighten spacing
- Adjust alphabetical navigation's sticky offset to sit closer to search bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e966c0a08322b3336c7293b178d4