### PR TITLE
Make alpha navigation transparent and improve accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -369,9 +369,9 @@ button, .value-card-toggle, .status-action-button {
     align-items: center;
     overflow-x: auto;
     white-space: nowrap;
-    background-color: var(--card-bg);
+    background-color: transparent;
     padding: 1rem 1rem;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    box-shadow: none;
 }
 
 .alpha-nav-horizontal a {
@@ -379,7 +379,7 @@ button, .value-card-toggle, .status-action-button {
     font-size: 1rem;
     padding: 0.25rem 0.5rem;
     margin-right: 0.25rem;
-    color: var(--accent-primary);
+    color: var(--text-main);
     border-radius: 4px;
     text-decoration: none;
     transition: background-color 0.2s;


### PR DESCRIPTION
## Summary
- Make alphabetical navigation bar transparent
- Use high-contrast text color for nav letters
- Keep active letter highlighted for current section

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c139c691c883229c6e5933a392ab9a