### PR TITLE
Wrap values layout and switch nav to vertical

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,78 +64,82 @@
             </div>
         </header>
 
-        <!-- Alphabetical Navigation -->
-        <nav class="alpha-nav-horizontal" id="alphaNav">
-            <!-- Will be populated by JavaScript -->
-        </nav>
+        <div class="values-layout">
+            <!-- Alphabetical Navigation -->
+            <nav class="alpha-nav-vertical" id="alphaNav">
+                <!-- Will be populated by JavaScript -->
+            </nav>
 
-        <!-- Advanced Filters Section -->
-        <div id="filtersContainer" class="filters-container mb-6 p-4">
-            <!-- Match Type Toggle -->
-            <div class="flex justify-between items-center mb-4 pb-2 border-b border-gray-200">
-                <div class="flex items-center">
-                    <span class="text-sm font-medium mr-2">Match Type:</span>
-                    <div class="toggle-container">
-                        <div id="toggleSlide" class="toggle-slide right"></div>
-                        <button id="matchAll" class="toggle-button opacity-75">All Selected Verbs</button>
-                        <button id="matchAny" class="toggle-button text-purple-800">Any Selected Verb</button>
-                    </div>
-                </div>
-                
-                <!-- Sort Options -->
-                <div class="flex items-center">
-                    <label for="sortSelect" class="text-sm font-medium mr-2">Sort By:</label>
-                    <select 
-                        id="sortSelect" 
-                        class="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-purple-500 text-sm bg-filter-bg"
-                    >
-                        <option value="name">Name</option>
-                        <option value="category">Category</option>
-                    </select>
-                </div>
-            </div>
-
-            <!-- Three-Column Layout for Filters -->
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <!-- Column 1: Categories -->
-                <div class="filter-column p-2 rounded-md">
-                    <div class="filter-header">Categories</div>
-                    <div id="categoryFilters" class="space-y-2">
-                        <!-- Categories will be added here by JavaScript -->
-                    </div>
-                    <button class="show-more-btn">Show More</button>
-                </div>
-                
-                <!-- Column 2: Tags/Verbs -->
-                <div class="filter-column p-2 rounded-md">
-                    <div class="filter-header">Verbs <span class="filter-caption">tags</span></div>
-                    <div id="tagFilters" class="space-y-1">
-                        <!-- Tags will be added here by JavaScript -->
-                    </div>
-                    <button class="show-more-btn">Show More</button>
-                </div>
-                
-                <!-- Column 3: Active Filters -->
-                <div class="filter-column p-2 rounded-md">
-                    <div class="filter-header">Active Filters</div>
-                    
-                    <!-- Active Filters -->
-                    <div>
-                        <div id="activeFilters" class="flex flex-wrap">
-                            <span id="noActiveFilters" class="text-xs opacity-75 italic">No active filters</span>
-                            <!-- Active filters will be added here by JavaScript -->
+            <div>
+                <!-- Advanced Filters Section -->
+                <div id="filtersContainer" class="filters-container mb-6 p-4">
+                    <!-- Match Type Toggle -->
+                    <div class="flex justify-between items-center mb-4 pb-2 border-b border-gray-200">
+                        <div class="flex items-center">
+                            <span class="text-sm font-medium mr-2">Match Type:</span>
+                            <div class="toggle-container">
+                                <div id="toggleSlide" class="toggle-slide right"></div>
+                                <button id="matchAll" class="toggle-button opacity-75">All Selected Verbs</button>
+                                <button id="matchAny" class="toggle-button text-purple-800">Any Selected Verb</button>
+                            </div>
                         </div>
-                        <button id="clearFilters" class="mt-4 reset-btn hidden">
-                            Clear All Filters
-                        </button>
+
+                        <!-- Sort Options -->
+                        <div class="flex items-center">
+                            <label for="sortSelect" class="text-sm font-medium mr-2">Sort By:</label>
+                            <select
+                                id="sortSelect"
+                                class="px-2 py-1 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-purple-500 text-sm bg-filter-bg"
+                            >
+                                <option value="name">Name</option>
+                                <option value="category">Category</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <!-- Three-Column Layout for Filters -->
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <!-- Column 1: Categories -->
+                        <div class="filter-column p-2 rounded-md">
+                            <div class="filter-header">Categories</div>
+                            <div id="categoryFilters" class="space-y-2">
+                                <!-- Categories will be added here by JavaScript -->
+                            </div>
+                            <button class="show-more-btn">Show More</button>
+                        </div>
+
+                        <!-- Column 2: Tags/Verbs -->
+                        <div class="filter-column p-2 rounded-md">
+                            <div class="filter-header">Verbs <span class="filter-caption">tags</span></div>
+                            <div id="tagFilters" class="space-y-1">
+                                <!-- Tags will be added here by JavaScript -->
+                            </div>
+                            <button class="show-more-btn">Show More</button>
+                        </div>
+
+                        <!-- Column 3: Active Filters -->
+                        <div class="filter-column p-2 rounded-md">
+                            <div class="filter-header">Active Filters</div>
+
+                            <!-- Active Filters -->
+                            <div>
+                                <div id="activeFilters" class="flex flex-wrap">
+                                    <span id="noActiveFilters" class="text-xs opacity-75 italic">No active filters</span>
+                                    <!-- Active filters will be added here by JavaScript -->
+                                </div>
+                                <button id="clearFilters" class="mt-4 reset-btn hidden">
+                                    Clear All Filters
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </div>
 
-        <!-- Values List -->
-        <div id="valuesList" class="space-y-4">
-            <!-- Values cards will be added here by JavaScript -->
+                <!-- Values List -->
+                <div id="valuesList" class="space-y-4">
+                    <!-- Values cards will be added here by JavaScript -->
+                </div>
+            </div>
         </div>
         
         <!-- Footer -->

--- a/style.css
+++ b/style.css
@@ -360,39 +360,67 @@ button, .value-card-toggle, .status-action-button {
     margin-left: 0.5rem;
 }
 
-/* Horizontal alphabetical navigation */
-.alpha-nav-horizontal {
+/* Values layout */
+.values-layout {
+    display: grid;
+    gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+    .values-layout {
+        grid-template-columns: 220px 1fr;
+        align-items: start;
+    }
+}
+
+/* Vertical alphabetical navigation */
+.alpha-nav-vertical {
     position: sticky;
     top: 4rem;
     z-index: 40;
     display: flex;
-    align-items: center;
-    overflow-x: auto;
-    white-space: nowrap;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    padding: 0.75rem 0.5rem;
     background-color: transparent;
-    padding: 1rem 1rem;
     box-shadow: none;
 }
 
-.alpha-nav-horizontal a {
-    flex: 0 0 auto;
+.alpha-nav-vertical a {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-size: 1rem;
     padding: 0.25rem 0.5rem;
-    margin-right: 0.25rem;
     color: var(--text-main);
     border-radius: 4px;
     text-decoration: none;
     transition: background-color 0.2s;
 }
 
-.alpha-nav-horizontal a:last-child {
-    margin-right: 0;
-}
-
-.alpha-nav-horizontal a:hover,
-.alpha-nav-horizontal a.active {
+.alpha-nav-vertical a:hover,
+.alpha-nav-vertical a.active {
     background-color: var(--accent-primary);
     color: var(--card-bg);
+}
+
+@media (min-width: 1024px) {
+    .alpha-nav-vertical {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 0.25rem;
+        padding: 1rem;
+        background-color: var(--card-bg);
+        border-radius: 8px;
+        box-shadow: 0 2px 5px rgba(0, 0, 0, 0.08);
+        max-height: calc(100vh - 6rem);
+        overflow-y: auto;
+    }
+
+    .alpha-nav-vertical a {
+        width: 100%;
+        padding: 0.35rem 0.75rem;
+    }
 }
 
 /* Back to top button */


### PR DESCRIPTION
## Summary
- wrap the alphabetical navigation, filters, and values list within a new `values-layout` container
- convert the alphabetical navigation to use the vertical variant and add supporting layout styles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cb028993bc8322a6ffc233161b6950