### PR TITLE
Adapt alpha navigation logic for vertical layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         </header>
 
         <!-- Alphabetical Navigation -->
-        <nav class="alpha-nav-horizontal" id="alphaNav">
+        <nav class="alpha-nav-vertical" id="alphaNav">
             <!-- Will be populated by JavaScript -->
         </nav>
 

--- a/script.js
+++ b/script.js
@@ -58,18 +58,89 @@ const filterState = {
 let currentLanguage = 'en';
 
 // Initialize DOM elements
-    let searchInput, mainSearchInput, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList,
+    let searchInput, mainSearchInput, mainSearchContainer, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList,
         matchAll, matchAny, toggleSlide, activeFilters, clearFilters, filterCount,
         toggleFilters, filtersContainer, valuesCount, alphaNav, backToTop, languageToggle;
 
 // Scroll spy handler reference
 let scrollSpyHandler;
 
+const ALPHA_NAV_STATE_CLASSES = {
+    active: ['is-active', 'active'],
+    above: ['is-above'],
+    below: ['is-below']
+};
+
+function getAlphaNavElement() {
+    if (alphaNav && document.body.contains(alphaNav)) {
+        return alphaNav;
+    }
+
+    alphaNav = document.querySelector('.alpha-nav-vertical');
+    if (!alphaNav) {
+        alphaNav = document.getElementById('alphaNav');
+    }
+
+    return alphaNav;
+}
+
+function updateAlphaNavLinkState(link, state) {
+    const validStates = Object.keys(ALPHA_NAV_STATE_CLASSES);
+    const normalizedState = validStates.includes(state) ? state : null;
+
+    validStates.forEach(key => {
+        const shouldHaveState = key === normalizedState;
+        ALPHA_NAV_STATE_CLASSES[key].forEach(className => {
+            link.classList.toggle(className, shouldHaveState);
+        });
+    });
+}
+
 // Helper to calculate the offset for alpha navigation
 function getAlphaNavOffset() {
-    if (!alphaNav) return 0;
-    const top = parseInt(getComputedStyle(alphaNav).top, 10);
-    return alphaNav.offsetHeight + (isNaN(top) ? 0 : top);
+    let offset = 0;
+    const stickyElements = new Set();
+
+    if (mainSearchContainer) {
+        stickyElements.add(mainSearchContainer);
+    }
+
+    document.querySelectorAll('[data-alpha-nav-offset]').forEach(element => {
+        stickyElements.add(element);
+    });
+
+    const nav = getAlphaNavElement();
+    if (nav && nav.dataset && nav.dataset.offsetTargets) {
+        nav.dataset.offsetTargets
+            .split(',')
+            .map(selector => selector.trim())
+            .filter(Boolean)
+            .forEach(selector => {
+                try {
+                    document.querySelectorAll(selector).forEach(element => stickyElements.add(element));
+                } catch (error) {
+                    console.warn(`Invalid selector in alpha nav offsetTargets: ${selector}`, error);
+                }
+            });
+    }
+
+    stickyElements.forEach(element => {
+        if (!element || !document.body.contains(element)) {
+            return;
+        }
+
+        const styles = getComputedStyle(element);
+        if (styles.position !== 'sticky' && styles.position !== 'fixed') {
+            return;
+        }
+
+        const top = parseFloat(styles.top);
+        const topOffset = isNaN(top) ? 0 : Math.max(top, 0);
+        const height = element.getBoundingClientRect().height;
+        offset = Math.max(offset, topOffset + height);
+    });
+
+    return offset;
 }
 
 // Wait for DOM to be fully loaded
@@ -80,6 +151,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Get DOM elements
         searchInput = document.getElementById('searchInput');
         mainSearchInput = document.getElementById('mainSearchInput');
+        mainSearchContainer = document.querySelector('.main-search-container');
         clearSearchBtn = document.getElementById('clearSearch');
         sortSelect = document.getElementById('sortSelect');
         tagFilters = document.getElementById('tagFilters');
@@ -94,7 +166,7 @@ document.addEventListener('DOMContentLoaded', function() {
         toggleFilters = document.getElementById('toggleFilters');
         filtersContainer = document.getElementById('filtersContainer');
         valuesCount = document.getElementById('valuesCount');
-        alphaNav = document.getElementById('alphaNav');
+        alphaNav = getAlphaNavElement();
         backToTop = document.getElementById('backToTop');
         languageToggle = document.getElementById('languageToggle');
 
@@ -165,7 +237,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Setup alphabetical navigation
 function setupAlphaNav() {
-    if (!alphaNav) return;
+    const nav = getAlphaNavElement();
+    if (!nav) return;
+
+    alphaNav = nav;
+    nav.innerHTML = '';
 
     // Create array of alphabet letters
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
@@ -189,7 +265,7 @@ function setupAlphaNav() {
                 findClosestSection(letter);
             }
         });
-        alphaNav.appendChild(link);
+        nav.appendChild(link);
     });
 }
 
@@ -225,24 +301,47 @@ function findClosestSection(letter) {
 
 // Highlight current section letter in navigation
 function setupScrollSpy() {
-    if (!alphaNav) return;
+    const nav = getAlphaNavElement();
+    if (!nav) return;
 
-    const sections = document.querySelectorAll('.letter-section');
-    const links = alphaNav.querySelectorAll('a[data-letter]');
+    alphaNav = nav;
+
+    const sections = Array.from(document.querySelectorAll('.letter-section'));
+    const links = Array.from(nav.querySelectorAll('a[data-letter]'));
 
     const handler = () => {
-        let current = sections.length > 0 ? sections[0].id.replace('section-','') : '';
-        for (const section of sections) {
-            const rect = section.getBoundingClientRect();
-            if (rect.top <= getAlphaNavOffset()) {
-                current = section.id.replace('section-','');
+        const offset = getAlphaNavOffset();
+        const sectionInfo = sections.map(section => ({
+            element: section,
+            letter: section.id.replace('section-', ''),
+            rect: section.getBoundingClientRect()
+        }));
+
+        let current = sectionInfo.length > 0 ? sectionInfo[0].letter : '';
+        for (const info of sectionInfo) {
+            if (info.rect.top - offset <= 0) {
+                current = info.letter;
             } else {
                 break;
             }
         }
 
+        const sectionMap = new Map(sectionInfo.map(info => [info.letter, info]));
+
         links.forEach(link => {
-            link.classList.toggle('active', link.dataset.letter === current);
+            const letter = link.dataset.letter;
+            const info = sectionMap.get(letter);
+
+            let state = 'below';
+            if (current && letter === current) {
+                state = 'active';
+            } else if (info) {
+                state = info.rect.top - offset < 0 ? 'above' : 'below';
+            } else if (current && letter < current) {
+                state = 'above';
+            }
+
+            updateAlphaNavLinkState(link, state);
         });
     };
 


### PR DESCRIPTION
## Summary
- update the alpha navigation setup to use the new `.alpha-nav-vertical` container and rebuild its links when initializing
- recalculate scroll targets based on the sticky header/search stack and keep scroll spy states in sync with the new above/below/active classes while retaining the legacy hook

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb028b62d88322acde6f4f9ec7d809