### PR TITLE
Restyle vertical alpha navigation layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,11 +64,6 @@
             </div>
         </header>
 
-        <!-- Alphabetical Navigation -->
-        <nav class="alpha-nav-horizontal" id="alphaNav">
-            <!-- Will be populated by JavaScript -->
-        </nav>
-
         <!-- Advanced Filters Section -->
         <div id="filtersContainer" class="filters-container mb-6 p-4">
             <!-- Match Type Toggle -->
@@ -133,9 +128,15 @@
             </div>
         </div>
 
-        <!-- Values List -->
-        <div id="valuesList" class="space-y-4">
-            <!-- Values cards will be added here by JavaScript -->
+        <!-- Alphabetical Navigation & Values List -->
+        <div class="values-layout">
+            <nav class="alpha-nav-vertical" id="alphaNav">
+                <!-- Will be populated by JavaScript -->
+            </nav>
+
+            <div id="valuesList" class="space-y-4">
+                <!-- Values cards will be added here by JavaScript -->
+            </div>
         </div>
         
         <!-- Footer -->

--- a/script.js
+++ b/script.js
@@ -58,18 +58,105 @@ const filterState = {
 let currentLanguage = 'en';
 
 // Initialize DOM elements
-    let searchInput, mainSearchInput, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList,
+    let searchInput, mainSearchInput, mainSearchContainer, clearSearchBtn, sortSelect, tagFilters, categoryFilters, valuesList,
         matchAll, matchAny, toggleSlide, activeFilters, clearFilters, filterCount,
         toggleFilters, filtersContainer, valuesCount, alphaNav, backToTop, languageToggle;
 
 // Scroll spy handler reference
 let scrollSpyHandler;
 
+const ALPHA_NAV_STATE_CLASSES = {
+    active: ['is-active', 'active'],
+    above: ['is-above'],
+    below: ['is-below']
+};
+
+function getAlphaNavElement() {
+    if (alphaNav && document.body.contains(alphaNav)) {
+        return alphaNav;
+    }
+
+    alphaNav = document.querySelector('.alpha-nav-vertical');
+    if (!alphaNav) {
+        alphaNav = document.getElementById('alphaNav');
+    }
+
+    return alphaNav;
+}
+
+function updateAlphaNavLinkState(link, state) {
+    const validStates = Object.keys(ALPHA_NAV_STATE_CLASSES);
+    const normalizedState = validStates.includes(state) ? state : null;
+
+    validStates.forEach(key => {
+        const shouldHaveState = key === normalizedState;
+        ALPHA_NAV_STATE_CLASSES[key].forEach(className => {
+            link.classList.toggle(className, shouldHaveState);
+        });
+    });
+}
+
 // Helper to calculate the offset for alpha navigation
 function getAlphaNavOffset() {
-    if (!alphaNav) return 0;
-    const top = parseInt(getComputedStyle(alphaNav).top, 10);
-    return alphaNav.offsetHeight + (isNaN(top) ? 0 : top);
+    let offset = 0;
+    const stickyElements = new Set();
+
+    if (mainSearchContainer) {
+        stickyElements.add(mainSearchContainer);
+    }
+
+    document.querySelectorAll('[data-alpha-nav-offset]').forEach(element => {
+        stickyElements.add(element);
+    });
+
+    const nav = getAlphaNavElement();
+    if (nav && nav.dataset && nav.dataset.offsetTargets) {
+        nav.dataset.offsetTargets
+            .split(',')
+            .map(selector => selector.trim())
+            .filter(Boolean)
+            .forEach(selector => {
+                try {
+                    document.querySelectorAll(selector).forEach(element => stickyElements.add(element));
+                } catch (error) {
+                    console.warn(`Invalid selector in alpha nav offsetTargets: ${selector}`, error);
+                }
+            });
+    }
+
+    stickyElements.forEach(element => {
+        if (!element || !document.body.contains(element)) {
+            return;
+        }
+
+        const styles = getComputedStyle(element);
+        const position = styles.position;
+        if (position !== 'sticky' && position !== 'fixed') {
+            return;
+        }
+
+        const rect = element.getBoundingClientRect();
+        if (rect.height <= 0) {
+            return;
+        }
+
+        if (position === 'fixed') {
+            offset = Math.max(offset, rect.bottom);
+            return;
+        }
+
+        const stickyTop = parseFloat(styles.top);
+        const pinThreshold = isNaN(stickyTop) ? 0 : stickyTop;
+        const tolerance = 1;
+
+        if (rect.top - pinThreshold > tolerance) {
+            offset = Math.max(offset, pinThreshold + rect.height);
+        } else {
+            offset = Math.max(offset, rect.bottom);
+        }
+    });
+
+    return Math.max(offset, 0);
 }
 
 // Wait for DOM to be fully loaded
@@ -80,6 +167,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Get DOM elements
         searchInput = document.getElementById('searchInput');
         mainSearchInput = document.getElementById('mainSearchInput');
+        mainSearchContainer = document.querySelector('.main-search-container');
         clearSearchBtn = document.getElementById('clearSearch');
         sortSelect = document.getElementById('sortSelect');
         tagFilters = document.getElementById('tagFilters');
@@ -94,7 +182,7 @@ document.addEventListener('DOMContentLoaded', function() {
         toggleFilters = document.getElementById('toggleFilters');
         filtersContainer = document.getElementById('filtersContainer');
         valuesCount = document.getElementById('valuesCount');
-        alphaNav = document.getElementById('alphaNav');
+        alphaNav = getAlphaNavElement();
         backToTop = document.getElementById('backToTop');
         languageToggle = document.getElementById('languageToggle');
 
@@ -165,7 +253,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
 // Setup alphabetical navigation
 function setupAlphaNav() {
-    if (!alphaNav) return;
+    const nav = getAlphaNavElement();
+    if (!nav) return;
+
+    alphaNav = nav;
+    nav.innerHTML = '';
 
     // Create array of alphabet letters
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
@@ -180,16 +272,27 @@ function setupAlphaNav() {
             e.preventDefault();
             const section = document.getElementById(`section-${letter}`);
             if (section) {
-                window.scrollTo({
-                    top: Math.max(section.offsetTop - getAlphaNavOffset(), 0),
-                    behavior: 'smooth'
-                });
+                scrollSectionIntoView(section);
             } else {
                 // If section doesn't exist, find closest available section
                 findClosestSection(letter);
             }
         });
-        alphaNav.appendChild(link);
+        nav.appendChild(link);
+    });
+}
+
+function scrollSectionIntoView(section) {
+    if (!section) return;
+
+    const rect = section.getBoundingClientRect();
+    const offset = getAlphaNavOffset();
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
+    const targetPosition = rect.top + scrollTop - offset;
+
+    window.scrollTo({
+        top: Math.max(targetPosition, 0),
+        behavior: 'smooth'
     });
 }
 
@@ -202,10 +305,7 @@ function findClosestSection(letter) {
     for (let i = letterIndex + 1; i < alphabet.length; i++) {
         const section = document.getElementById(`section-${alphabet[i]}`);
         if (section) {
-            window.scrollTo({
-                top: Math.max(section.offsetTop - getAlphaNavOffset(), 0),
-                behavior: 'smooth'
-            });
+            scrollSectionIntoView(section);
             return;
         }
     }
@@ -214,10 +314,7 @@ function findClosestSection(letter) {
     for (let i = letterIndex - 1; i >= 0; i--) {
         const section = document.getElementById(`section-${alphabet[i]}`);
         if (section) {
-            window.scrollTo({
-                top: Math.max(section.offsetTop - getAlphaNavOffset(), 0),
-                behavior: 'smooth'
-            });
+            scrollSectionIntoView(section);
             return;
         }
     }
@@ -225,32 +322,57 @@ function findClosestSection(letter) {
 
 // Highlight current section letter in navigation
 function setupScrollSpy() {
-    if (!alphaNav) return;
+    const nav = getAlphaNavElement();
+    if (!nav) return;
 
-    const sections = document.querySelectorAll('.letter-section');
-    const links = alphaNav.querySelectorAll('a[data-letter]');
+    alphaNav = nav;
+
+    const sections = Array.from(document.querySelectorAll('.letter-section'));
+    const links = Array.from(nav.querySelectorAll('a[data-letter]'));
 
     const handler = () => {
-        let current = sections.length > 0 ? sections[0].id.replace('section-','') : '';
-        for (const section of sections) {
-            const rect = section.getBoundingClientRect();
-            if (rect.top <= getAlphaNavOffset()) {
-                current = section.id.replace('section-','');
+        const offset = getAlphaNavOffset();
+        const sectionInfo = sections.map(section => ({
+            element: section,
+            letter: section.id.replace('section-', ''),
+            rect: section.getBoundingClientRect()
+        }));
+
+        let current = sectionInfo.length > 0 ? sectionInfo[0].letter : '';
+        for (const info of sectionInfo) {
+            if (info.rect.top - offset <= 0) {
+                current = info.letter;
             } else {
                 break;
             }
         }
 
+        const sectionMap = new Map(sectionInfo.map(info => [info.letter, info]));
+
         links.forEach(link => {
-            link.classList.toggle('active', link.dataset.letter === current);
+            const letter = link.dataset.letter;
+            const info = sectionMap.get(letter);
+
+            let state = 'below';
+            if (current && letter === current) {
+                state = 'active';
+            } else if (info) {
+                state = info.rect.top - offset < 0 ? 'above' : 'below';
+            } else if (current && letter < current) {
+                state = 'above';
+            }
+
+            updateAlphaNavLinkState(link, state);
         });
     };
 
     if (scrollSpyHandler) {
         window.removeEventListener('scroll', scrollSpyHandler);
+        window.removeEventListener('resize', scrollSpyHandler);
     }
     scrollSpyHandler = handler;
     window.addEventListener('scroll', handler);
+    window.addEventListener('resize', handler);
     handler();
 }
 

--- a/style.css
+++ b/style.css
@@ -360,39 +360,111 @@ button, .value-card-toggle, .status-action-button {
     margin-left: 0.5rem;
 }
 
-/* Horizontal alphabetical navigation */
-.alpha-nav-horizontal {
+/* Alphabetical navigation layout */
+.values-layout {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.25rem;
+}
+
+.values-layout #valuesList {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.alpha-nav-vertical {
     position: sticky;
-    top: 4rem;
+    top: 6.5rem;
     z-index: 40;
     display: flex;
+    flex-direction: column;
+    align-self: flex-start;
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem 0.5rem 0.5rem;
+    border-radius: 0.75rem;
+    background-color: rgba(255, 255, 255, 0.35);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 4px 10px rgba(10, 62, 147, 0.08);
+    min-width: 4rem;
+}
+
+.alpha-nav-vertical a {
+    display: inline-flex;
     align-items: center;
-    overflow-x: auto;
-    white-space: nowrap;
-    background-color: transparent;
-    padding: 1rem 1rem;
-    box-shadow: none;
-}
-
-.alpha-nav-horizontal a {
-    flex: 0 0 auto;
-    font-size: 1rem;
-    padding: 0.25rem 0.5rem;
-    margin-right: 0.25rem;
-    color: var(--text-main);
-    border-radius: 4px;
+    color: var(--text-secondary);
+    font-weight: 500;
+    font-size: 0.95rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 9999px;
     text-decoration: none;
-    transition: background-color 0.2s;
+    transition: color 0.2s ease, background-color 0.2s ease, font-weight 0.2s ease;
 }
 
-.alpha-nav-horizontal a:last-child {
-    margin-right: 0;
+.alpha-nav-vertical a.is-above {
+    color: rgba(102, 102, 102, 0.75);
+    font-weight: 400;
 }
 
-.alpha-nav-horizontal a:hover,
-.alpha-nav-horizontal a.active {
-    background-color: var(--accent-primary);
+.alpha-nav-vertical a.is-below {
+    color: rgba(102, 102, 102, 0.55);
+    font-weight: 400;
+}
+
+.alpha-nav-vertical a:hover {
+    color: var(--text-main);
+    font-weight: 600;
+}
+
+.alpha-nav-vertical a.is-active,
+.alpha-nav-vertical a.active {
+    background-color: var(--accent-secondary);
     color: var(--card-bg);
+    font-weight: 700;
+    box-shadow: 0 2px 8px rgba(61, 220, 199, 0.4);
+}
+
+.alpha-nav-vertical a.is-active::before,
+.alpha-nav-vertical a.active::before {
+    content: '';
+    display: inline-block;
+    width: 0.35rem;
+    height: 0.35rem;
+    margin-right: 0.35rem;
+    border-radius: 9999px;
+    background-color: currentColor;
+}
+
+@media (max-width: 1024px) {
+    .values-layout {
+        gap: 1rem;
+    }
+
+    .alpha-nav-vertical {
+        top: 5.75rem;
+        padding-right: 0.5rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .values-layout {
+        flex-direction: column;
+    }
+
+    .alpha-nav-vertical {
+        position: static;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        padding: 0.75rem 1rem;
+        background-color: rgba(255, 255, 255, 0.6);
+        width: 100%;
+        justify-content: flex-start;
+    }
+
+    .alpha-nav-vertical a {
+        font-size: 0.9rem;
+        padding: 0.4rem 0.65rem;
+    }
 }
 
 /* Back to top button */


### PR DESCRIPTION
## Summary
- wrap the alpha navigation and values list in a shared flex layout so the sticky nav aligns alongside the cards
- restyle the `.alpha-nav-vertical` component with vertical spacing, accentuated active states, and lighter above/below treatments
- add responsive rules to collapse the layout on smaller viewports while keeping the nav accessible

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb028b62d88322acde6f4f9ec7d809