### PR TITLE
Enhance alpha navigation emphasis

### DIFF
--- a/style.css
+++ b/style.css
@@ -382,14 +382,10 @@ button, .value-card-toggle, .status-action-button {
     flex-direction: column;
     gap: 0.5rem;
     padding: 1rem;
-    background: rgba(255, 255, 255, 0.95);
+    background: transparent;
     border-radius: 12px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    border: 1px solid rgba(128, 90, 213, 0.12);
     max-height: calc(100vh - 40px);
     overflow-y: auto;
-    backdrop-filter: blur(6px);
-    -webkit-backdrop-filter: blur(6px);
 }
 
 .alpha-nav-list {
@@ -413,40 +409,39 @@ button, .value-card-toggle, .status-action-button {
 
 .alpha-nav-item {
     border-radius: 6px;
-    transition: transform 0.2s ease;
 }
 
 .alpha-nav-link {
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 0.5rem 0.75rem;
+    padding: 0.4rem 0.65rem;
     color: var(--text-main);
-    font-size: 0.95rem;
-    font-weight: 500;
+    font-size: 1.5rem;
+    font-weight: 600;
     text-decoration: none;
     border-radius: 6px;
-    transition: color 0.3s ease, background-color 0.3s ease, transform 0.2s ease;
+    transform: scale(1);
+    transition: color 0.25s ease, transform 0.25s ease, text-shadow 0.25s ease;
 }
 
 .alpha-nav-link:hover,
 .alpha-nav-link:focus,
 .alpha-nav-link:focus-visible {
-    background-color: rgba(128, 90, 213, 0.12);
-    color: var(--header-text);
+    color: var(--accent-primary);
     outline: none;
-    box-shadow: 0 0 0 3px rgba(128, 90, 213, 0.15);
+    text-shadow: 0 4px 12px rgba(128, 90, 213, 0.35);
+    transform: scale(1.3);
 }
 
 .alpha-nav-item.active {
-    transform: translateX(4px);
+    transform: none;
 }
 
 .alpha-nav-item.active .alpha-nav-link {
-    background-color: var(--accent-primary);
-    color: var(--card-bg);
-    box-shadow: 0 2px 6px rgba(128, 90, 213, 0.25);
-    font-weight: 600;
+    color: var(--accent-primary);
+    text-shadow: 0 6px 18px rgba(128, 90, 213, 0.45);
+    transform: scale(1.35);
 }
 
 .alpha-nav-vertical::-webkit-scrollbar {
@@ -523,7 +518,7 @@ button, .value-card-toggle, .status-action-button {
     }
 
     .alpha-nav-link {
-        min-width: 2.5rem;
+        min-width: 3.25rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- enlarge alphabetical navigation characters and add smooth scaling for hover and active states
- remove the navigation background styling to expose the page backdrop
- tweak responsive sizing so larger letters retain spacing on small screens

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dcea6b62188322b8bc1e756c0df58a