### PR TITLE
Fix read less arrow orientation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1145,7 +1145,7 @@ function displayValues(valuesToDisplay) {
                 toggleButton.addEventListener('click', () => {
                     card.classList.toggle('expanded');
                     toggleButton.innerHTML = card.classList.contains('expanded')
-                        ? 'Read less <i class="fas fa-chevron-up"></i>'
+                        ? 'Read less <i class="fas fa-chevron-down"></i>'
                         : 'Read more <i class="fas fa-chevron-down"></i>';
                 });
 


### PR DESCRIPTION
## Summary
- keep the chevron-down icon for the value card toggle in both states so the CSS rotation shows an up arrow when expanded

## Testing
- manual

------
https://chatgpt.com/codex/tasks/task_e_68def104fccc8322a4bc838e7d162c9d