### PR TITLE
Show chevron up icon when cards are expanded

### DIFF
--- a/script.js
+++ b/script.js
@@ -1145,7 +1145,7 @@ function displayValues(valuesToDisplay) {
                 toggleButton.addEventListener('click', () => {
                     card.classList.toggle('expanded');
                     toggleButton.innerHTML = card.classList.contains('expanded')
-                        ? 'Read less <i class="fas fa-chevron-down"></i>'
+                        ? 'Read less <i class="fas fa-chevron-up"></i>'
                         : 'Read more <i class="fas fa-chevron-down"></i>';
                 });
 


### PR DESCRIPTION
## Summary
- update value card toggle to show a chevron-up icon when the card is expanded with the Read less label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def426daf083228812db294a0d16b3