### PR TITLE
Fix expanded value card caret orientation

### DIFF
--- a/style.css
+++ b/style.css
@@ -599,11 +599,6 @@ button, .value-card-toggle, .status-action-button {
 
 .value-card-toggle i {
     margin-left: 6px;
-    transition: transform 0.3s;
-}
-
-.value-card.expanded .value-card-toggle i {
-    transform: rotate(180deg);
 }
 
 /* Section labels */


### PR DESCRIPTION
## Summary
- remove the transform-based rotation on the value card toggle icon
- rely on the icon swap so the expanded state shows an upward caret as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df18c498008322bd2ae5eacfebeba0