### PR TITLE
Adjust mobile back-to-top positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -520,6 +520,13 @@ button, .value-card-toggle, .status-action-button {
     .alpha-nav-link {
         min-width: 3.25rem;
     }
+
+    .back-to-top {
+        bottom: 72px;
+        right: 16px;
+        bottom: calc(72px + env(safe-area-inset-bottom));
+        right: calc(16px + env(safe-area-inset-right));
+    }
 }
 
 /* Back to top button */


### PR DESCRIPTION
## Summary
- reposition the back-to-top button on narrow screens so it no longer overlaps the mobile alphabetical navigation
- add safe-area-aware offsets to respect devices with display notches when positioning the button

## Testing
- Manually verified in a 390x844 viewport


------
https://chatgpt.com/codex/tasks/task_e_68df1f24e97c83228eccac83479859b4