### PR TITLE
Add compact synopsis preview for collapsed gallery cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -2926,6 +2926,9 @@ function displayValues(valuesToDisplay) {
                 const category = document.createElement('span');
                 category.textContent = getCategoryLabel(value.category);
                 category.classList.add('category-badge');
+                const description = document.createElement('p');
+                description.textContent = value.description;
+                description.classList.add('mb-4', 'value-description');
                 let meta = null;
                 category.addEventListener('click', () => {
                     // Add category to filters
@@ -2955,28 +2958,19 @@ function displayValues(valuesToDisplay) {
                     meta = document.createElement('div');
                     meta.classList.add('value-card-meta');
                     meta.appendChild(title);
+                    description.classList.add('value-description--gallery');
+                    meta.appendChild(description);
                     previewContainer.appendChild(meta);
                 } else {
                     header.appendChild(title);
                     header.appendChild(category);
                     previewContainer.appendChild(header);
-
-                    const description = document.createElement('p');
-                    description.textContent = value.description;
-                    description.classList.add('mb-4', 'value-description');
                     previewContainer.appendChild(description);
                 }
 
                 // Create content container (for collapsible functionality)
                 const contentContainer = document.createElement('div');
                 contentContainer.classList.add('value-card-content');
-
-                if (currentViewMode === 'gallery') {
-                    const description = document.createElement('p');
-                    description.textContent = value.description;
-                    description.classList.add('mb-4', 'value-description', 'value-description--gallery');
-                    meta.appendChild(description);
-                }
 
                 // Add the example of value in action with label
                 const exampleContainer = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -1979,15 +1979,21 @@ button, .value-card-toggle, .status-action-button {
 
 .values-list--gallery .value-description--gallery {
     margin: 0;
-    max-height: 0;
-    opacity: 0;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
     overflow: hidden;
-    transform: translateY(0.35rem);
-    transition: max-height 0.35s ease, opacity 0.24s ease, transform 0.3s ease;
+    opacity: 0.92;
+    transform: translateY(0.15rem);
+    transition: opacity 0.24s ease, transform 0.3s ease;
 }
 
 .values-list--gallery .value-card.expanded .value-description--gallery {
-    max-height: 12rem;
+    display: block;
+    -webkit-line-clamp: unset;
+    line-clamp: unset;
+    overflow: visible;
     opacity: 1;
     transform: translateY(0);
 }


### PR DESCRIPTION
### Motivation
- Provide a compact, two-line synopsis for gallery cards when collapsed so users see a short preview instead of nothing.
- Preserve the current read more / read less toggle behavior so expanded cards still show the full description.

### Description
- Update `style.css` so `.values-list--gallery .value-description--gallery` uses CSS line clamping (`-webkit-line-clamp: 2`) to show a two-line synopsis and remove the previous `max-height: 0` hiding behavior. 
- Ensure expanded gallery cards (`.values-list--gallery .value-card.expanded .value-description--gallery`) unset the clamp and allow the full text to display by restoring `display`, `overflow`, and removing the clamp.
- Refactor `script.js` to always create a single description `<p>` node for a value and keep it in the DOM, appending it into the gallery meta or list preview as appropriate so CSS alone controls truncation/expansion instead of conditionally adding/removing the element.
- Leave toggle and expansion logic unchanged so the `read more` / `read less` labels, ARIA attributes, and `expanded` class behavior continue to control card state.

### Testing
- Ran `node --check script.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de477eb7888322a53f730e92dbf540)