### PR TITLE
Refine gallery grid and expanded card layout in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -1285,7 +1285,7 @@ button, .value-card-toggle, .status-action-button {
 .letter-values-grid--gallery {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     align-items: start;
-    grid-auto-flow: row dense;
+    grid-auto-flow: row;
 }
 
 @media (min-width: 900px) {

--- a/style.css
+++ b/style.css
@@ -1285,17 +1285,20 @@ button, .value-card-toggle, .status-action-button {
 .letter-values-grid--gallery {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     align-items: start;
+    grid-auto-flow: row;
 }
 
 @media (min-width: 900px) {
     .letter-values-grid--gallery {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        gap: 1.25rem;
     }
 
     .letter-values-grid--gallery .value-card--gallery.expanded {
         grid-column: 1 / -1;
-        justify-self: start;
-        width: min(100%, 1000px);
+        justify-self: center;
+        width: 100%;
+        max-width: 1120px;
     }
 
     .letter-values-grid--gallery .value-card--gallery.expanded .value-card-layout--gallery {


### PR DESCRIPTION
### Motivation
- Improve responsiveness and centering of the gallery grid and expanded value cards at larger viewports.
- Ensure gallery items flow correctly and the expanded card width is constrained for better visual balance.

### Description
- Added `grid-auto-flow: row` to `.letter-values-grid--gallery` to ensure consistent row flow. 
- Changed grid sizing at `@media (min-width: 900px)` from `repeat(2, minmax(0, 1fr))` to `repeat(auto-fit, minmax(300px, 1fr))` and added `gap: 1.25rem` for better responsiveness and spacing. 
- Centered expanded gallery cards by replacing `justify-self: start` with `justify-self: center` and replaced `width: min(100%, 1000px)` with `width: 100%` plus `max-width: 1120px` to constrain expansion.

### Testing
- No automated tests were added for these CSS changes. 
- Local visual/manual verification was performed to confirm responsive behavior and centering at `min-width: 900px` (no automated regressions run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de49916bb08322969f8ce3544a3ee0)