### PR TITLE
Disable dense packing in gallery grid to preserve source order

### DIFF
--- a/style.css
+++ b/style.css
@@ -1285,7 +1285,8 @@ button, .value-card-toggle, .status-action-button {
 .letter-values-grid--gallery {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     align-items: start;
-    grid-auto-flow: row dense;
+    /* Keep source order stable; dense packing can visually reorder cards. */
+    grid-auto-flow: row;
 }
 
 @media (min-width: 900px) {


### PR DESCRIPTION
### Motivation
- Prevent visual reordering of gallery cards caused by dense grid packing so items render in source order.

### Description
- In `style.css` changed `.letter-values-grid--gallery` from `grid-auto-flow: row dense;` to `grid-auto-flow: row;` and added a comment explaining the reason.

### Testing
- No automated tests were run for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d1b8ddfc83229f33dbc42465e3f6)