### PR TITLE
Refine gallery grid sizing and expanded card centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -1283,7 +1283,7 @@ button, .value-card-toggle, .status-action-button {
 }
 
 .letter-values-grid--gallery {
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
     align-items: start;
     grid-auto-flow: row dense;
 }
@@ -1297,8 +1297,8 @@ button, .value-card-toggle, .status-action-button {
     .letter-values-grid--gallery .value-card--gallery.expanded {
         grid-column: 1 / -1;
         justify-self: center;
-        width: 100%;
-        max-width: 1120px;
+        margin-inline: auto;
+        width: min(100%, 1120px);
     }
 
     .letter-values-grid--gallery .value-card--gallery.expanded .value-card-layout--gallery {


### PR DESCRIPTION
### Motivation
- Reduce cramped card widths and accidental whitespace gaps on mid-to-large screens while preserving dense packing and the existing mobile fallback.

### Description
- Increased the gallery baseline auto-fit minimum from `minmax(260px, 1fr)` to `minmax(280px, 1fr)` and preserved `grid-auto-flow: row dense` for tighter packing.
- Kept the desktop adaptive template at the `@media (min-width: 900px)` breakpoint using `repeat(auto-fit, minmax(300px, 1fr))` to improve large-screen usage.
- Adjusted expanded gallery cards to span the full row and center using `margin-inline: auto` with `width: min(100%, 1120px)` instead of separate `width`/`max-width` declarations.
- Left mobile fallback rules (`@media (max-width: 640px)`) and expanded-layout fallbacks unchanged.

### Testing
- Ran `rg -n "letter-values-grid--gallery|value-card--gallery|expanded|@media" style.css` to confirm selectors and occurrences (succeeded).
- Ran `git diff -- style.css` to verify the intended edits to `style.css` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e32ee58c832292cd5fdf504d4663)