### PR TITLE
Update homepage intro copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <h1 class="hero-title"><a class="hero-title__link" href="/" data-i18n="page.heading">TURN VALUES INTO VERBS</a></h1>
             <div class="intro-box intro-box--editorial">
                 <p data-i18n="page.introDescription">
-                    A living encyclopedia for defining what matters most through applicable everyday behaviors. Because values are only as good as the actions that back them up.
+                    Turn values into verbs. A system for putting principles into practice.
                 </p>
             </div>
             <div class="flex items-center justify-between values-header">

--- a/script.js
+++ b/script.js
@@ -175,8 +175,8 @@ const i18n = {
         page: {
             title: 'The Howdy Human Dictionary of Values',
             heading: 'TURN VALUES INTO VERBS',
-            tagline: 'A living encyclopedia for defining what matters most through applicable everyday behaviors. Because values are only as good as the actions that back them up.',
-            introDescription: 'A living encyclopedia for defining what matters most through applicable everyday behaviors. Because values are only as good as the actions that back them up.',
+            tagline: 'Turn values into verbs. A system for putting principles into practice.',
+            introDescription: 'Turn values into verbs. A system for putting principles into practice.',
             introInstructions: '<li>Choose a verb</li><li>Open a value</li><li>Save what resonates</li>'
         },
         buttons: {


### PR DESCRIPTION
### Motivation
- Replace the existing homepage intro copy with the new two-line messaging to better reflect the site tagline: `Turn values into verbs.` and `A system for putting principles into practice.`

### Description
- Updated the static HTML fallback in `index.html` and the English i18n strings (`page.tagline` and `page.introDescription`) in `script.js` so the frontend and translations show the new copy consistently.

### Testing
- Searched the repository for the new strings using `rg -n "Turn values into verbs|A system for putting principles into practice" index.html script.js` and inspected the updated lines with `nl -ba index.html | sed -n '70,85p'` and `nl -ba script.js | sed -n '170,186p'`, and the checks showed the new copy present in both files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4d9ec20083229e5159d05b4767ca)