### PR TITLE
Improve search relevance ordering to prioritize exact typed value

### DIFF
--- a/script.js
+++ b/script.js
@@ -686,7 +686,7 @@ function updateSearchClearButtons(hasValue) {
 
 function setSearchTerm(value, { sourceInput = null, updateUI = true } = {}) {
     const term = value ?? '';
-    filterState.searchTerm = term.toLowerCase();
+    filterState.searchTerm = normalizeSearchText(term);
 
     if (mainSearchInput && mainSearchInput !== sourceInput) {
         mainSearchInput.value = term;
@@ -3283,7 +3283,39 @@ function filterValues() {
         }
 
         // Sort results
-        if (filterState.sortMethod === 'name') {
+        if (filterState.searchTerm) {
+            const searchTerm = filterState.searchTerm;
+            const getRelevanceScore = (value) => {
+                const normalizedName = normalizeSearchText(value.name);
+                const normalizedDescription = normalizeSearchText(value.description);
+                const normalizedExample = normalizeSearchText(value.example);
+                const normalizedCategory = normalizeSearchText(value.category);
+                const normalizedCategoryLabel = normalizeSearchText(getCategoryLabel(value.category));
+                const normalizedTags = value.tags.map((tag) => normalizeSearchText(tag));
+
+                if (normalizedName === searchTerm) return 0;
+                if (normalizedName.startsWith(searchTerm)) return 1;
+                if (normalizedTags.some((tag) => tag === searchTerm)) return 2;
+                if (normalizedTags.some((tag) => tag.startsWith(searchTerm))) return 3;
+                if (normalizedName.includes(searchTerm)) return 4;
+                if (normalizedDescription.includes(searchTerm)) return 5;
+                if (normalizedExample.includes(searchTerm)) return 6;
+                if (normalizedCategory === searchTerm || normalizedCategoryLabel === searchTerm) return 7;
+                if (normalizedCategory.includes(searchTerm) || normalizedCategoryLabel.includes(searchTerm)) return 8;
+                return 9;
+            };
+
+            filtered.sort((a, b) => {
+                const scoreDiff = getRelevanceScore(a) - getRelevanceScore(b);
+                if (scoreDiff !== 0) return scoreDiff;
+
+                if (filterState.sortMethod === 'category') {
+                    return compareByName(a.category, b.category) || compareByName(a.name, b.name);
+                }
+
+                return compareByName(a.name, b.name);
+            });
+        } else if (filterState.sortMethod === 'name') {
             filtered.sort((a, b) => compareByName(a.name, b.name));
         } else if (filterState.sortMethod === 'category') {
             filtered.sort((a, b) => compareByName(a.category, b.category) || compareByName(a.name, b.name));


### PR DESCRIPTION
### Motivation
- Ensure typed queries return the exact value first and related/close matches afterward so the search feels intuitive when users type a full value name. 

### Description
- Use the existing locale- and diacritic-aware helper by setting `filterState.searchTerm = normalizeSearchText(term)` in `setSearchTerm` so queries are normalized consistently. 
- Add a relevance-based ranking in `filterValues` when a search term is present that scores results by exact name match, name prefix, tag exact/prefix matches, partial name match, description/example matches, then category matches. 
- Preserve the existing `sortMethod` (`name`/`category`) as a tiebreaker when relevance scores are equal. 
- Changes made in `script.js` (search normalization and relevance-sorting logic). 

### Testing
- No automated test suite found in this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f82ba234208322a15a240a1ba1d106)