### PR TITLE
Translate A–Z browser label

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                         data-i18n="aria.alphaNav"
                         data-i18n-attr="aria-label"
                     >
-                        <div class="alpha-nav-inline__label">Browse A–Z</div>
+                        <div class="alpha-nav-inline__label" data-i18n="alphaNav.label">Browse A–Z</div>
                         <ul class="alpha-nav-list" role="list">
                             <!-- Will be populated by JavaScript -->
                         </ul>

--- a/script.js
+++ b/script.js
@@ -194,6 +194,7 @@ const i18n = {
             gallery: 'Gallery'
         },
         alphaNav: {
+            label: 'Browse A–Z',
             overlayHint: 'Jump to a letter to browse matching values.',
             closeLabel: 'Close navigation'
         },
@@ -302,6 +303,7 @@ const i18n = {
             gallery: 'Galería'
         },
         alphaNav: {
+            label: 'Explorar de A a Z',
             overlayHint: 'Elige una letra para explorar los valores relacionados.',
             closeLabel: 'Cerrar navegación'
         },


### PR DESCRIPTION
### Motivation
- The alphabetical navigation label was hard-coded in English and didn’t participate in the existing i18n flow, so it displayed as `Browse A–Z` on the Spanish site instead of a localized string.

### Description
- Added `data-i18n="alphaNav.label"` to the A–Z label in `index.html` and added `alphaNav.label` translations for English (`Browse A–Z`) and Spanish (`Explorar de A a Z`) in `script.js` so the label is translated via the existing `translate` pipeline.

### Testing
- Ran `node --check script.js` which completed without errors, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08e459683c83228c80815fa76583de)