### PR TITLE
Fix Spanish hero tagline translation

### DIFF
--- a/script.js
+++ b/script.js
@@ -284,8 +284,8 @@ const i18n = {
         page: {
             title: 'El Diccionario de Valores de Howdy Human',
             heading: 'CONVIERTE VALORES EN VERBOS',
-            tagline: 'Una enciclopedia viva para definir lo que más importa mediante comportamientos cotidianos aplicables. Los valores solo valen por las acciones que los respaldan.',
-            introDescription: 'Una enciclopedia viva para definir lo que más importa mediante comportamientos cotidianos aplicables. Los valores solo valen por las acciones que los respaldan.',
+            tagline: 'Convierte los valores en verbos. Un sistema para poner principios en práctica.',
+            introDescription: 'Convierte los valores en verbos. Un sistema para poner principios en práctica.',
             introInstructions: '<li>Elige un verbo</li><li>Abre un valor</li><li>Guarda lo que resuene</li>'
         },
         buttons: {


### PR DESCRIPTION
### Motivation
- Align the Spanish hero text with the concise English phrasing instead of using an editorial rewrite that changed tone and focus.

### Description
- Replace the Spanish `page.tagline` and `page.introDescription` strings in `script.js` with `Convierte los valores en verbos. Un sistema para poner principios en práctica.`.

### Testing
- Automated checks `node --check script.js` and `git diff --check` were run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09d06c6e8c83229b95e42d40d2e737)