### PR TITLE
Add vibes to values as verbs essay

### DIFF
--- a/values-as-verbs/index.html
+++ b/values-as-verbs/index.html
@@ -4,19 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Values as Verbs: Turn Values Into Action | Howdy Human</title>
-  <meta name="description" content="Learn how to turn values into verbs with Howdy Human's values-as-verbs framework for recognizing values through everyday actions.">
+  <meta name="description" content="Learn how to turn values into verbs and vibes with Howdy Human's framework for recognizing values through actions, motives, and everyday patterns.">
   <link rel="canonical" href="https://www.howdyhuman.com/values-as-verbs/">
 
   <meta property="og:site_name" content="Howdy Human">
   <meta property="og:title" content="Values as Verbs: Turn Values Into Action">
-  <meta property="og:description" content="Learn the Howdy Human framework for recognizing values through everyday actions, choices, and patterns.">
+  <meta property="og:description" content="Learn the Howdy Human framework for recognizing values through everyday actions, choices, motives, and patterns.">
   <meta property="og:url" content="https://www.howdyhuman.com/values-as-verbs/">
   <meta property="og:type" content="article">
   <meta property="og:image" content="https://www.howdyhuman.com/social/og-home.png">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Values as Verbs: Turn Values Into Action">
-  <meta name="twitter:description" content="A practical framework for recognizing values through everyday actions.">
+  <meta name="twitter:description" content="A practical framework for recognizing values through everyday actions and the feelings driving them.">
   <meta name="twitter:image" content="https://www.howdyhuman.com/social/og-home.png">
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
@@ -217,7 +217,7 @@
       <header class="hero">
         <p class="eyebrow">Howdy Human Framework</p>
         <h1>Values as Verbs: How to Turn What Matters Into What You Do</h1>
-        <p class="dek">A practical way to recognize values through actions, choices, patterns, and everyday proof.</p>
+        <p class="dek">A practical way to recognize values through actions, choices, patterns, motives, and everyday proof.</p>
       </header>
 
       <div class="content">
@@ -225,7 +225,7 @@
 
         <p>Most people talk about values as nouns. Courage. Integrity. Compassion. Creativity. Freedom. The words are useful, but they can also become strangely weightless. A value can sound beautiful on a page and still remain hard to recognize in a life. You can say you value courage and still wonder what courage actually asks of you on a Tuesday afternoon. You can say you value connection and still miss the small ways connection is already happening through a text, a meal, a boundary, or a question asked with real attention.</p>
 
-        <p>Howdy Human starts from a simple premise: a value is easier to understand when you can see what it does. Values become visible through verbs. They show up when someone speaks, listens, protects, repairs, studies, rests, tries, gives, refuses, creates, waits, or begins again. The point is not to reduce a value to one behavior. The point is to make the value observable enough that a person can notice it, name it, and choose how to practice it more deliberately.</p>
+        <p>Howdy Human starts from a simple premise: a value is easier to understand when you can see what it does. Values become visible through verbs. They show up when someone speaks, listens, protects, repairs, studies, rests, tries, gives, refuses, creates, waits, or begins again. But verbs are only one part of the signal. The feeling around the action matters too: the anxiety before it, the relief after it, the sense of openness, tightness, pride, resentment, calm, depletion, or clarity it leaves behind. In other words, values show up through verbs and vibes. The point is not to reduce a value to one behavior or one mood. The point is to make the value observable enough that a person can notice it, name it, and choose how to practice it more deliberately.</p>
 
         <p>This matters because values are often treated like personality traits, moral labels, or aspirational slogans. That can make them feel distant from daily life. A values-as-verbs approach brings them back down to the ground. Instead of asking, "What do I believe I value?" it asks, "What am I doing repeatedly, and what value might that action be serving?" That shift turns values from abstract ideals into patterns you can actually work with.</p>
 
@@ -241,6 +241,14 @@
           <p><strong>Core idea:</strong> values are not only things you have. They are things you do, things you protect, things you repeat, and things you choose under pressure.</p>
         </div>
 
+        <h2>Where Vibes Fit</h2>
+
+        <p>Vibes are the felt context around the verb. They are not proof by themselves, but they help you interpret the action with more honesty. Two people can do the same thing for very different reasons. You might clean your kitchen from care, control, avoidance, peace, self-respect, or a need to feel less scattered. The verb is "cleaned." The vibe tells you what the action was trying to serve.</p>
+
+        <p>In a values practice, a vibe can mean the emotional tone, the body signal, the craving, the relief, or the atmosphere an action creates. Before the action, were you anxious, excited, bored, tender, restless, or grounded? During it, did your body feel tight, open, heavy, energized, or numb? After it, did you feel proud, resentful, calm, depleted, clearer, or more connected? Those details help separate a value from a coping strategy, and they make room for more compassionate interpretation.</p>
+
+        <p>This is especially useful when the behavior looks messy. Avoiding an email might be a weak strategy, but the vibe around it may reveal a real value underneath: safety, autonomy, dignity, peace, or control. Overworking might point to ambition or responsibility, but the depleted feeling afterward may show that the way you are serving that value needs to change. The vibe does not excuse every tactic. It helps you understand what the tactic was protecting.</p>
+
         <h2>Why Values Are Easier to Recognize Through Action</h2>
 
         <p>Human beings are not always accurate reporters of their own priorities. We may describe ourselves according to who we want to be, who we used to be, or who we think we should be. Action gives us another source of evidence. It does not tell the whole truth, but it tells a useful truth. Where time goes, where attention returns, what gets defended, what gets avoided, what gets practiced, and what gets repaired all reveal something about what is active in a person's life.</p>
@@ -253,10 +261,11 @@
 
         <h2>The Howdy Human Framework</h2>
 
-        <p>The Howdy Human framework is built around observation, translation, and reflection. First, observe the action. Then, translate the action into possible values. Finally, reflect on whether the value feels aligned, alive, or incomplete.</p>
+        <p>The Howdy Human framework is built around observation, translation, and reflection. First, observe the action. Then, notice the vibe around it. Translate both into possible values. Finally, reflect on whether the value feels aligned, alive, or incomplete.</p>
 
         <ol>
           <li><strong>Notice the verb.</strong> Start with what actually happened. "I called." "I organized." "I avoided." "I asked." "I stayed." Clean verbs reduce the temptation to over-explain.</li>
+          <li><strong>Notice the vibe.</strong> Capture what was driving the action and what it felt like before, during, and after. Was there relief, pressure, joy, fear, steadiness, resentment, pride, numbness, or clarity?</li>
           <li><strong>Name the context.</strong> A behavior means different things in different settings. Resting after burnout is not the same as hiding from a necessary conversation. Speaking up in a meeting is not the same as dominating it.</li>
           <li><strong>Infer the value.</strong> Ask what the action may have been trying to serve. Was it protecting peace, seeking truth, building trust, creating beauty, preserving energy, or reaching for connection?</li>
           <li><strong>Check the strategy.</strong> An action can point to a real value even when the strategy is messy. Avoiding a hard email might be trying to protect safety. Spending too much might be seeking comfort or identity. The value can be real while the tactic still needs adjustment.</li>
@@ -294,17 +303,17 @@
           </div>
         </div>
 
-        <p>These verbs make values easier to spot in daily life. If you are trying to understand what you value, you can look at the verbs that keep recurring. If you are trying to live a value more fully, you can choose a verb that gives it a body. If you want more courage, you might practice asking one honest question. If you want more care, you might prepare the thing that makes tomorrow gentler. If you want more creativity, you might make a rough draft before you know whether it is good.</p>
+        <p>These verbs make values easier to spot in daily life. The vibes around them make values easier to understand. If you are trying to understand what you value, you can look at the verbs that keep recurring and the feelings that keep surrounding them. If you are trying to live a value more fully, you can choose a verb that gives it a body and a vibe that tells you whether it is nourishing, performative, protective, or misaligned. If you want more courage, you might practice asking one honest question and notice whether the fear gives way to relief. If you want more care, you might prepare the thing that makes tomorrow gentler and notice whether your body softens. If you want more creativity, you might make a rough draft before you know whether it is good and notice whether the act leaves you more alive.</p>
 
         <h2>How to Use This Framework in Daily Life</h2>
 
-        <p>You can use the values-as-verbs framework in a quick daily reflection, a weekly review, a coaching session, a journal practice, or a team conversation. The process does not need to be complicated. Start with one area of life and list a few actions you took recently. Use plain verbs. Then ask what value each action might reveal.</p>
+        <p>You can use the values-as-verbs framework in a quick daily reflection, a weekly review, a coaching session, a journal practice, or a team conversation. The process does not need to be complicated. Start with one area of life and list a few actions you took recently. Use plain verbs. Then add the vibe: what you were feeling before, what you wanted, how your body felt while doing it, and how you felt afterward. From there, ask what value each action might reveal.</p>
 
         <p>For example, if you wrote, "researched apartments, called my sister, postponed the invoice, cleaned the kitchen, walked alone," you might see several active values. Researching could point to stability, independence, or foresight. Calling your sister could point to connection or loyalty. Postponing the invoice might reveal avoidance, but underneath it there may be fear, scarcity, or a desire for control. Cleaning the kitchen could point to care, order, or peace. Walking alone could point to mental health, freedom, or stillness.</p>
 
         <p>The goal is not to judge every action as good or bad. The goal is to listen to behavior as information. A values-based living practice becomes stronger when it can hold both celebration and course correction.</p>
 
-        <p>A useful prompt is: "What value was this action trying to serve?" Another is: "If I wanted to serve that value with more honesty next time, what would I do?" These questions make the framework immediately practical. They move you from interpretation to choice.</p>
+        <p>A useful prompt is: "What value was this action trying to serve?" Another is: "What was this action trying to protect?" A third is: "If I wanted to serve that value with more honesty next time, what would I do?" These questions make the framework immediately practical. They move you from interpretation to choice.</p>
 
         <h2>From Naming Values to Living Them</h2>
 
@@ -312,12 +321,12 @@
 
         <p>This is the promise of turning values into verbs. It gives people a way to see themselves more clearly without pretending to be finished. It helps values become less about self-branding and more about self-observation. It creates a bridge between the life you are already living and the life you want to practice on purpose.</p>
 
-        <p>Howdy Human is a dictionary of values, but the deeper invitation is not just to read definitions. It is to notice the verbs that are already shaping your days. Some will affirm you. Some will challenge you. Some will show you where a value is alive but under-supported. Some will show you where an old strategy is asking to be retired.</p>
+        <p>Howdy Human is a dictionary of values, but the deeper invitation is not just to read definitions. It is to notice the verbs already shaping your days and the vibes that tell you what those verbs are doing to your inner life. Some will affirm you. Some will challenge you. Some will show you where a value is alive but under-supported. Some will show you where an old strategy is asking to be retired.</p>
 
         <p>Values become useful when they can help you choose. They become trustworthy when they can survive contact with ordinary life. They become yours when you can recognize them in action and decide, with more honesty, what you want to do next.</p>
 
         <div class="cta">
-          <p><strong>Explore the dictionary.</strong> Use the <a href="/">Howdy Human Dictionary of Values</a> to look up value words, notice their associated verbs, and start translating what matters into what you do.</p>
+          <p><strong>Explore the dictionary.</strong> Use the <a href="/">Howdy Human Dictionary of Values</a> to look up value words, notice their associated verbs, and start translating what matters into what you do and how it feels to do it.</p>
           <p>Start with <a href="/values/courage/">Courage</a>, <a href="/values/integrity/">Integrity</a>, <a href="/values/compassion/">Compassion</a>, or <a href="/values/creativity/">Creativity</a>.</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Adds a new "Where Vibes Fit" section to the Values as Verbs essay.
- Updates the framework steps to include noticing the vibe around an action.
- Refreshes metadata, intro, daily-use prompts, and CTA language around verbs plus vibes.

## Validation
- Parsed `values-as-verbs/index.html` with Python's HTML parser.
- Previewed the page locally at `http://localhost:8765/values-as-verbs/`.
- Confirmed the new section rendered correctly in the browser preview.
