### PR TITLE
Remove homepage framework links

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,8 +130,6 @@
                     <div class="site-menu__section">
                         <p class="site-menu__label" data-i18n="menu.pagesLabel">Pages</p>
                         <a class="site-menu__link" href="/">Field Guide</a>
-                        <a class="site-menu__link" href="/values-as-verbs/">Values as Verbs</a>
-                        <a class="site-menu__link" href="/values-in-action-audit/">Values-in-Action Audit</a>
                         <a class="site-menu__link" href="#homepage-category-index-heading">Browse Categories</a>
                     </div>
                     <div class="site-menu__section">
@@ -232,10 +230,6 @@
             <div class="intro-box intro-box--editorial">
                 <p data-i18n="page.introDescription">
                     Turn values into verbs. A system for putting principles into practice.
-                </p>
-                <p class="mb-3">
-                    <a class="intro-framework-link" href="/values-as-verbs/">Learn the values-as-verbs framework</a>.
-                    <a class="intro-framework-link" href="/values-in-action-audit/">Try the values-in-action audit</a>.
                 </p>
             </div>
             <div class="flex items-center justify-between values-header">


### PR DESCRIPTION
### Motivation
- Remove two specific links to the framework and audit from the homepage to simplify the menu and intro while preserving editable copy. 

### Description
- Edited `index.html` to remove the `Values as Verbs` and `Values-in-Action Audit` menu links from the site menu. 
- Removed the intro paragraph that contained the `Learn the values-as-verbs framework` and `Try the values-in-action audit` links while leaving the surrounding intro text intact. 
- No other homepage copy or structure was changed.

### Testing
- Ran `rg -n "Values as Verbs|Values-in-Action Audit|Learn the values-as-verbs framework|Try the values-in-action audit|intro-framework-link" index.html; test $? -eq 1` to confirm removed strings are no longer present, and it succeeded. 
- Ran `git status --short` to verify `index.html` is the only modified file, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d34f52bec83228ecb6c03b3f13ff4)