### PR TITLE
Replace site palettes with four new palettes (Meadow Bloom default)

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,66 +156,54 @@
                             aria-controls="paletteOptions"
                         >
                             <span data-i18n="menu.paletteAction">Choose palette</span>
-                            <span class="site-menu__palette-current" id="currentPaletteName">Canyon Disco</span>
+                            <span class="site-menu__palette-current" id="currentPaletteName">Meadow Bloom</span>
                         </button>
                         <div class="palette-options" id="paletteOptions" role="radiogroup" aria-label="Choose palette">
-                            <button class="palette-option" type="button" data-palette="canyon-disco" role="radio" aria-checked="true">
+                            <button class="palette-option" type="button" data-palette="meadow-bloom" role="radio" aria-checked="true">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #ff6f3c"></span>
-                                    <span style="--swatch: #246b5a"></span>
-                                    <span style="--swatch: #f3c13a"></span>
+                                    <span style="--swatch: #225F45"></span>
+                                    <span style="--swatch: #3F8F7A"></span>
+                                    <span style="--swatch: #F2C14E"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Canyon Disco</span>
-                                    <span class="palette-option__code">CANYON</span>
+                                    <span class="palette-option__name">Meadow Bloom</span>
+                                    <span class="palette-option__code">MEADOW</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
-                            <button class="palette-option" type="button" data-palette="cosmic-yard" role="radio" aria-checked="false">
+                            <button class="palette-option" type="button" data-palette="sunlit-clay" role="radio" aria-checked="false">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #2f6f78"></span>
-                                    <span style="--swatch: #ff9b73"></span>
-                                    <span style="--swatch: #d5e96f"></span>
+                                    <span style="--swatch: #8A3F2D"></span>
+                                    <span style="--swatch: #246B5A"></span>
+                                    <span style="--swatch: #E8B84A"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Dusk Garden</span>
-                                    <span class="palette-option__code">DUSK</span>
+                                    <span class="palette-option__name">Sunlit Clay</span>
+                                    <span class="palette-option__code">CLAY</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
-                            <button class="palette-option" type="button" data-palette="tomato-sky" role="radio" aria-checked="false">
+                            <button class="palette-option" type="button" data-palette="deep-garden" role="radio" aria-checked="false">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #d9412f"></span>
-                                    <span style="--swatch: #2e8dbd"></span>
-                                    <span style="--swatch: #f7d26a"></span>
+                                    <span style="--swatch: #9FE0C5"></span>
+                                    <span style="--swatch: #F2C14E"></span>
+                                    <span style="--swatch: #C9E86A"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Tomato Sky</span>
-                                    <span class="palette-option__code">TOMATO</span>
+                                    <span class="palette-option__name">Deep Garden</span>
+                                    <span class="palette-option__code">GARDEN</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
-                            <button class="palette-option" type="button" data-palette="juniper-lime" role="radio" aria-checked="false">
+                            <button class="palette-option" type="button" data-palette="ink-lavender" role="radio" aria-checked="false">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #1f6f62"></span>
-                                    <span style="--swatch: #b7e54a"></span>
-                                    <span style="--swatch: #7b4ee6"></span>
+                                    <span style="--swatch: #D6C6FF"></span>
+                                    <span style="--swatch: #8EE0D1"></span>
+                                    <span style="--swatch: #F3A6C8"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Juniper Lime</span>
-                                    <span class="palette-option__code">JUNIPER</span>
-                                </span>
-                                <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
-                            </button>
-                            <button class="palette-option" type="button" data-palette="ink-peach" role="radio" aria-checked="false">
-                                <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #26324f"></span>
-                                    <span style="--swatch: #ff9d76"></span>
-                                    <span style="--swatch: #7fd6c2"></span>
-                                </span>
-                                <span class="palette-option__text">
-                                    <span class="palette-option__name">Ink & Peach</span>
-                                    <span class="palette-option__code">PEACH</span>
+                                    <span class="palette-option__name">Ink Lavender</span>
+                                    <span class="palette-option__code">LAVENDER</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>

--- a/script.js
+++ b/script.js
@@ -62,14 +62,13 @@ const filterState = {
 let selectedVerb = null;
 const DICTIONARY_VIEW_MODE_STORAGE_KEY = 'dictionaryViewMode';
 const SITE_PALETTE_STORAGE_KEY = 'sitePalette';
-const DEFAULT_SITE_PALETTE = 'canyon-disco';
-const SITE_PALETTE_IDS = ['canyon-disco', 'cosmic-yard', 'tomato-sky', 'juniper-lime', 'ink-peach'];
+const DEFAULT_SITE_PALETTE = 'meadow-bloom';
+const SITE_PALETTE_IDS = ['meadow-bloom', 'sunlit-clay', 'deep-garden', 'ink-lavender'];
 const SITE_PALETTE_NAMES = {
-    'canyon-disco': 'Canyon Disco',
-    'cosmic-yard': 'Dusk Garden',
-    'tomato-sky': 'Tomato Sky',
-    'juniper-lime': 'Juniper Lime',
-    'ink-peach': 'Ink & Peach'
+    'meadow-bloom': 'Meadow Bloom',
+    'sunlit-clay': 'Sunlit Clay',
+    'deep-garden': 'Deep Garden',
+    'ink-lavender': 'Ink Lavender'
 };
 
 function getStoredViewMode() {

--- a/style.css
+++ b/style.css
@@ -2658,7 +2658,25 @@ body {
     transform: scale(1);
 }
 
-body[data-palette="canyon-disco"] {
+body[data-palette="meadow-bloom"] {
+    --background: #f6f4ff;
+    --bg-main-rgb: 246, 244, 255;
+    --card-bg: #fbfafc;
+    --card-bg-rgb: 251, 250, 252;
+    --text-primary: #1f2a2a;
+    --text-secondary: #495452;
+    --text-secondary-rgb: 73, 84, 82;
+    --accent-primary: #225f45;
+    --accent-primary-rgb: 34, 95, 69;
+    --accent-secondary: #3f8f7a;
+    --accent-secondary-rgb: 63, 143, 122;
+    --header-text: #225f45;
+    --filter-bg: #eeedf8;
+    --tag-bg: #f2c14e;
+    --support-saffron-rgb: 242, 193, 78;
+}
+
+body[data-palette="sunlit-clay"] {
     --background: #fff7ed;
     --bg-main-rgb: 255, 247, 237;
     --card-bg: #fffcf7;
@@ -2666,86 +2684,50 @@ body[data-palette="canyon-disco"] {
     --text-primary: #2d241c;
     --text-secondary: #57483d;
     --text-secondary-rgb: 87, 72, 61;
-    --accent-primary: #246b5a;
-    --accent-primary-rgb: 36, 107, 90;
-    --accent-secondary: #ff6f3c;
-    --accent-secondary-rgb: 255, 111, 60;
-    --header-text: #246b5a;
+    --accent-primary: #8a3f2d;
+    --accent-primary-rgb: 138, 63, 45;
+    --accent-secondary: #246b5a;
+    --accent-secondary-rgb: 36, 107, 90;
+    --header-text: #8a3f2d;
     --filter-bg: #fff0df;
-    --tag-bg: #f3c13a;
-    --support-saffron-rgb: 243, 193, 58;
+    --tag-bg: #e8b84a;
+    --support-saffron-rgb: 232, 184, 74;
 }
 
-body[data-palette="cosmic-yard"] {
-    --background: #46666d;
-    --bg-main-rgb: 70, 102, 109;
-    --card-bg: #58767c;
-    --card-bg-rgb: 88, 118, 124;
+body[data-palette="deep-garden"] {
+    --background: #18332d;
+    --bg-main-rgb: 24, 51, 45;
+    --card-bg: #24443c;
+    --card-bg-rgb: 36, 68, 60;
     --text-primary: #fff8ef;
-    --text-secondary: #e7f1ed;
-    --text-secondary-rgb: 231, 241, 237;
-    --accent-primary: #ffb08a;
-    --accent-primary-rgb: 255, 176, 138;
-    --accent-secondary: #d5e96f;
-    --accent-secondary-rgb: 213, 233, 111;
-    --header-text: #fff0dc;
-    --filter-bg: #5f7e82;
-    --tag-bg: #d5e96f;
-    --support-saffron-rgb: 213, 233, 111;
+    --text-secondary: #ddebe5;
+    --text-secondary-rgb: 221, 235, 229;
+    --accent-primary: #9fe0c5;
+    --accent-primary-rgb: 159, 224, 197;
+    --accent-secondary: #f2c14e;
+    --accent-secondary-rgb: 242, 193, 78;
+    --header-text: #fff8ef;
+    --filter-bg: #24443c;
+    --tag-bg: #c9e86a;
+    --support-saffron-rgb: 201, 232, 106;
 }
 
-body[data-palette="tomato-sky"] {
-    --background: #fff8f2;
-    --bg-main-rgb: 255, 248, 242;
-    --card-bg: #fffdfa;
-    --card-bg-rgb: 255, 253, 250;
-    --text-primary: #2b2522;
-    --text-secondary: #534741;
-    --text-secondary-rgb: 83, 71, 65;
-    --accent-primary: #d9412f;
-    --accent-primary-rgb: 217, 65, 47;
-    --accent-secondary: #2e8dbd;
-    --accent-secondary-rgb: 46, 141, 189;
-    --header-text: #c53b2b;
-    --filter-bg: #fbece5;
-    --tag-bg: #f7d26a;
-    --support-saffron-rgb: 247, 210, 106;
-}
-
-body[data-palette="juniper-lime"] {
-    --background: #f8fbef;
-    --bg-main-rgb: 248, 251, 239;
-    --card-bg: #fdfff9;
-    --card-bg-rgb: 253, 255, 249;
-    --text-primary: #172b26;
-    --text-secondary: #43524d;
-    --text-secondary-rgb: 67, 82, 77;
-    --accent-primary: #1f6f62;
-    --accent-primary-rgb: 31, 111, 98;
-    --accent-secondary: #7b4ee6;
-    --accent-secondary-rgb: 123, 78, 230;
-    --header-text: #1f6f62;
-    --filter-bg: #eff7db;
-    --tag-bg: #b7e54a;
-    --support-saffron-rgb: 183, 229, 74;
-}
-
-body[data-palette="ink-peach"] {
-    --background: #566073;
-    --bg-main-rgb: 86, 96, 115;
-    --card-bg: #687184;
-    --card-bg-rgb: 104, 113, 132;
-    --text-primary: #fff4ea;
-    --text-secondary: #f2ded1;
-    --text-secondary-rgb: 242, 222, 209;
-    --accent-primary: #ffb18d;
-    --accent-primary-rgb: 255, 177, 141;
-    --accent-secondary: #94ead7;
-    --accent-secondary-rgb: 148, 234, 215;
-    --header-text: #ffe3d2;
-    --filter-bg: #687184;
-    --tag-bg: #94ead7;
-    --support-saffron-rgb: 148, 234, 215;
+body[data-palette="ink-lavender"] {
+    --background: #252a44;
+    --bg-main-rgb: 37, 42, 68;
+    --card-bg: #323852;
+    --card-bg-rgb: 50, 56, 82;
+    --text-primary: #fff7f0;
+    --text-secondary: #e8deea;
+    --text-secondary-rgb: 232, 222, 234;
+    --accent-primary: #d6c6ff;
+    --accent-primary-rgb: 214, 198, 255;
+    --accent-secondary: #8ee0d1;
+    --accent-secondary-rgb: 142, 224, 209;
+    --header-text: #fff7f0;
+    --filter-bg: #323852;
+    --tag-bg: #f3a6c8;
+    --support-saffron-rgb: 243, 166, 200;
 }
 
 .hero-shell {


### PR DESCRIPTION
### Motivation
- Standardize the site to exactly four color palettes and make a calm, nature-forward `meadow-bloom` the default. 
- Ensure the palette picker, runtime palette constants, and CSS variables remain consistent across `index.html`, `script.js`, and `style.css`.

### Description
- Updated JavaScript palette constants by setting `DEFAULT_SITE_PALETTE` to `meadow-bloom`, replacing `SITE_PALETTE_IDS` with `['meadow-bloom','sunlit-clay','deep-garden','ink-lavender']`, and updating `SITE_PALETTE_NAMES` accordingly in `script.js`.
- Replaced the five `.palette-option` buttons in `index.html` with exactly four buttons for `meadow-bloom`, `sunlit-clay`, `deep-garden`, and `ink-lavender`, updated the visible names, short codes, default `aria-checked` state, and inline swatch colors, and set `#currentPaletteName` to “Meadow Bloom”.
- Replaced the five `body[data-palette="..."]` CSS blocks in `style.css` with four new blocks for the new palette IDs and defined the required CSS variables (`--background`, `--bg-main-rgb`, `--card-bg`, `--card-bg-rgb`, `--text-primary`, `--text-secondary`, `--text-secondary-rgb`, `--accent-primary`, `--accent-primary-rgb`, `--accent-secondary`, `--accent-secondary-rgb`, `--header-text`, `--filter-bg`, `--tag-bg`, `--support-saffron-rgb`) for each palette.

### Testing
- Ran `python3 -m pytest` and all tests passed (`5 passed`).
- Ran an automated contrast check script (WCAG luminance/contrast calculations) against palette foreground/background combinations and the script returned `PASS` for the required checks.
- Confirmed the UI palette markup contains exactly four `.palette-option` buttons via a small Python/grep check that counted 4.
- Attempted to install screenshot tooling, but `npx` install failed with `403 Forbidden` from the npm registry in this environment (installation not performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d34bd7df48322a40562288a7636c6)