### PR TITLE
Remove deprecated SEO static pages from generator

### DIFF
--- a/generate_seo_pages.py
+++ b/generate_seo_pages.py
@@ -8,6 +8,13 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 DATA_FILE = ROOT / 'Values-en.json'
 SITE_URL = 'https://www.howdyhuman.com'
+
+DEPRECATED_STATIC_PAGE_SLUGS = {
+    'values-as-verbs',
+    'values-in-action-audit',
+    'values-in-action-check-in',
+}
+
 EXPANDED_VALUE_SLUGS = {
     'courage',
     'integrity',
@@ -1374,6 +1381,20 @@ def ensure_clean_directory(parent: Path, valid_slugs: set[str]) -> None:
             child.rmdir()
 
 
+def remove_deprecated_static_pages() -> None:
+    for slug in DEPRECATED_STATIC_PAGE_SLUGS:
+        page_dir = ROOT / slug
+        if not page_dir.is_dir():
+            continue
+        for nested in page_dir.rglob('*'):
+            if nested.is_file():
+                nested.unlink()
+        for nested in sorted(page_dir.rglob('*'), reverse=True):
+            if nested.is_dir():
+                nested.rmdir()
+        page_dir.rmdir()
+
+
 def write_sitemap(value_slugs: list[str], category_slugs: list[str]) -> None:
     urls = [f'{SITE_URL}/']
     urls.extend(f'{SITE_URL}/values/category/{slug}/' for slug in category_slugs)
@@ -1878,6 +1899,7 @@ def build_verb_page(tag: str, values_for_tag: list[dict]) -> tuple[str, str]:
 
 
 def category_index_markup(categories: dict[str, list[dict]], heading_id: str = 'category-index-heading') -> str:
+    heading_i18n = ' data-i18n="categories.indexHeading"' if heading_id == 'homepage-category-index-heading' else ''
     cards = []
     for category, category_values in sorted(categories.items(), key=lambda pair: pair[0].lower()):
         sorted_values = sorted(category_values, key=lambda item: item['name'].lower())
@@ -1894,7 +1916,7 @@ def category_index_markup(categories: dict[str, list[dict]], heading_id: str = '
 
     return f"""
                         <section class="seo-category-index" aria-labelledby="{html.escape(heading_id)}">
-                            <h2 id="{html.escape(heading_id)}" class="text-2xl font-bold mt-8 mb-4 py-2 border-b border-gray-300 letter-section">Browse by category</h2>
+                            <h2 id="{html.escape(heading_id)}" class="text-2xl font-bold mt-8 mb-4 py-2 border-b border-gray-300 letter-section"{heading_i18n}>Browse by category</h2>
                             <div class="seo-category-grid">{''.join(cards)}
                             </div>
                         </section>"""
@@ -1977,6 +1999,8 @@ def main() -> None:
     values_dir.mkdir(exist_ok=True)
     categories_dir.mkdir(parents=True, exist_ok=True)
     verbs_dir.mkdir(exist_ok=True)
+
+    remove_deprecated_static_pages()
 
     values_by_tag: dict[str, list[dict]] = {}
     values_by_category: dict[str, list[dict]] = {}


### PR DESCRIPTION
### Motivation
- Prevent generation or resurrection of three legacy static pages (`values-as-verbs`, `values-in-action-audit`, `values-in-action-check-in`) that should no longer exist on the site.
- Ensure the static generator also cleans up any leftover local directories for those deprecated pages when regenerating site output.
- Preserve the homepage category heading i18n marker when regenerating the homepage fallback HTML.

### Description
- Added a `DEPRECATED_STATIC_PAGE_SLUGS` set and implemented `remove_deprecated_static_pages()` to delete matching legacy directories if present. The function is invoked during generation before pages are rebuilt.
- Kept the sitemap generation limited to current generated URLs so deprecated pages are not reintroduced to `sitemap.xml`.
- Modified `category_index_markup()` to preserve the homepage category heading `data-i18n="categories.indexHeading"` when rendering the homepage fallback.
- Regenerated static output as part of the run, which updated `index.html` and refreshed generated pages and `sitemap.xml`.

### Testing
- Ran `python generate_seo_pages.py` to regenerate static pages and it completed successfully.
- Ran unit tests with `python -m unittest discover -s tests` and all tests passed (`Ran 5 tests, OK`).
- Verified with a grep check that the deprecated slugs do not appear in `sitemap.xml` or `index.html` after generation (no matches returned).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d3a7eac1c83229a7af281215018b0)