### PR TITLE
Replace site palette with Texas editorial nature palette

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,38 +15,38 @@
       display: grid;
       place-items: center;
       font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-      background: #edf4ef;
-      color: #1f2a2a;
+      background: #f3eee6;
+      color: #2b2a26;
       text-align: center;
       padding: 1.5rem;
     }
     .card {
-      background: white;
+      background: #fbf7ef;
       border-radius: 18px;
       padding: 1.75rem 1.5rem;
-      box-shadow: 0 10px 28px rgba(0, 0, 0, 0.08);
+      box-shadow: 0 10px 28px rgba(43, 42, 38, 0.08);
       max-width: 420px;
       width: min(90vw, 420px);
-      border: 1px solid rgba(139, 108, 207, 0.2);
+      border: 1px solid rgba(199, 189, 169, 0.55);
     }
     h1 {
       margin: 0 0 0.5rem;
       font-size: 1.5rem;
-      color: #264136;
+      color: #3b4137;
     }
     p {
       margin: 0 0 1rem;
-      color: #495452;
+      color: #5d5a52;
       line-height: 1.5;
     }
     a {
-      color: #3a7240;
+      color: #536b55;
       font-weight: 700;
       text-decoration: none;
     }
     a:hover,
     a:focus-visible {
-      color: #8b6ccf;
+      color: #8b654f;
       outline: none;
     }
   </style>

--- a/generate_seo_pages.py
+++ b/generate_seo_pages.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import html
 import hashlib
 import json
@@ -1341,23 +1343,23 @@ def html_page(
   <link rel=\"icon\" type=\"image/x-icon\" href=\"/favicon.ico\" />
   <link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/apple-touch-icon.png\" />
 {extra}  <style>
-    body {{ font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }}
+    body {{ font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }}
     main {{ max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }}
-    article {{ background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }}
-    h1 {{ margin-top: 0; line-height: 1.2; }}
-    h2 {{ margin-top: 1.5rem; font-size: 1.1rem; }}
+    article {{ background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }}
+    h1 {{ margin-top: 0; line-height: 1.2; color: #3b4137; }}
+    h2 {{ margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }}
     p {{ margin: .65rem 0; }}
     ul {{ margin: .5rem 0 0; padding-left: 1.1rem; }}
-    a {{ color: #225f45; }}
-    .meta {{ color: #495452; font-size: .95rem; }}
-    .breadcrumbs {{ display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }}
-    .breadcrumbs a {{ color: #225f45; text-decoration: none; }}
+    a {{ color: #536b55; }}
+    .meta {{ color: #5d5a52; font-size: .95rem; }}
+    .breadcrumbs {{ display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }}
+    .breadcrumbs a {{ color: #536b55; text-decoration: none; }}
     .breadcrumbs a:hover {{ text-decoration: underline; }}
-    .chip {{ display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }}
+    .chip {{ display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }}
     .category-value-list {{ display: grid; gap: .75rem; padding-left: 0; list-style: none; }}
-    .category-value-list li {{ border-top: 1px solid #e5eee8; padding-top: .75rem; }}
+    .category-value-list li {{ border-top: 1px solid #ded5c5; padding-top: .75rem; }}
     .category-value-list a {{ display: block; font-weight: 700; }}
-    .category-value-list span {{ display: block; margin-top: .2rem; color: #495452; }}
+    .category-value-list span {{ display: block; margin-top: .2rem; color: #5d5a52; }}
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-    <meta name="theme-color" content="#225f45">
+    <meta name="theme-color" content="#536b55">
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -80,7 +80,7 @@
     </script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=menu-palette-20260617">
+    <link rel="stylesheet" href="style.css?v=texas-editorial-20260707">
 </head>
 <body>
     <noscript>
@@ -154,54 +154,54 @@
                             aria-controls="paletteOptions"
                         >
                             <span data-i18n="menu.paletteAction">Choose palette</span>
-                            <span class="site-menu__palette-current" id="currentPaletteName">Meadow Bloom</span>
+                            <span class="site-menu__palette-current" id="currentPaletteName">Hill Country</span>
                         </button>
                         <div class="palette-options" id="paletteOptions" role="radiogroup" aria-label="Choose palette">
-                            <button class="palette-option" type="button" data-palette="meadow-bloom" role="radio" aria-checked="true">
+                            <button class="palette-option" type="button" data-palette="hill-country" role="radio" aria-checked="true">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #225F45"></span>
-                                    <span style="--swatch: #3F8F7A"></span>
-                                    <span style="--swatch: #F2C14E"></span>
+                                    <span style="--swatch: #536B55"></span>
+                                    <span style="--swatch: #7B6A53"></span>
+                                    <span style="--swatch: #DFCFAA"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Meadow Bloom</span>
-                                    <span class="palette-option__code">MEADOW</span>
+                                    <span class="palette-option__name">Hill Country</span>
+                                    <span class="palette-option__code">LIMESTONE</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
-                            <button class="palette-option" type="button" data-palette="sunlit-clay" role="radio" aria-checked="false">
+                            <button class="palette-option" type="button" data-palette="live-oak" role="radio" aria-checked="false">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #8A3F2D"></span>
-                                    <span style="--swatch: #246B5A"></span>
-                                    <span style="--swatch: #E8B84A"></span>
+                                    <span style="--swatch: #465C49"></span>
+                                    <span style="--swatch: #6F7D68"></span>
+                                    <span style="--swatch: #D9CFAA"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Sunlit Clay</span>
+                                    <span class="palette-option__name">Live Oak</span>
+                                    <span class="palette-option__code">SAGE</span>
+                                </span>
+                                <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
+                            </button>
+                            <button class="palette-option" type="button" data-palette="big-bend" role="radio" aria-checked="false">
+                                <span class="palette-option__swatches" aria-hidden="true">
+                                    <span style="--swatch: #8B654F"></span>
+                                    <span style="--swatch: #5F716B"></span>
+                                    <span style="--swatch: #D8BD8C"></span>
+                                </span>
+                                <span class="palette-option__text">
+                                    <span class="palette-option__name">Big Bend</span>
                                     <span class="palette-option__code">CLAY</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
-                            <button class="palette-option" type="button" data-palette="deep-garden" role="radio" aria-checked="false">
+                            <button class="palette-option" type="button" data-palette="gulf-rain" role="radio" aria-checked="false">
                                 <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #9FE0C5"></span>
-                                    <span style="--swatch: #F2C14E"></span>
-                                    <span style="--swatch: #C9E86A"></span>
+                                    <span style="--swatch: #556F6A"></span>
+                                    <span style="--swatch: #6F8580"></span>
+                                    <span style="--swatch: #D4C7A2"></span>
                                 </span>
                                 <span class="palette-option__text">
-                                    <span class="palette-option__name">Deep Garden</span>
-                                    <span class="palette-option__code">GARDEN</span>
-                                </span>
-                                <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
-                            </button>
-                            <button class="palette-option" type="button" data-palette="ink-lavender" role="radio" aria-checked="false">
-                                <span class="palette-option__swatches" aria-hidden="true">
-                                    <span style="--swatch: #D6C6FF"></span>
-                                    <span style="--swatch: #8EE0D1"></span>
-                                    <span style="--swatch: #F3A6C8"></span>
-                                </span>
-                                <span class="palette-option__text">
-                                    <span class="palette-option__name">Ink Lavender</span>
-                                    <span class="palette-option__code">LAVENDER</span>
+                                    <span class="palette-option__name">Gulf Rain</span>
+                                    <span class="palette-option__code">DUST BLUE</span>
                                 </span>
                                 <i class="fas fa-check palette-option__check" aria-hidden="true"></i>
                             </button>
@@ -1461,6 +1461,6 @@
         </footer>
     </div>
 
-    <script src="script.js?v=menu-palette-20260617"></script>
+    <script src="script.js?v=texas-editorial-20260707"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -62,13 +62,13 @@ const filterState = {
 let selectedVerb = null;
 const DICTIONARY_VIEW_MODE_STORAGE_KEY = 'dictionaryViewMode';
 const SITE_PALETTE_STORAGE_KEY = 'sitePalette';
-const DEFAULT_SITE_PALETTE = 'meadow-bloom';
-const SITE_PALETTE_IDS = ['meadow-bloom', 'sunlit-clay', 'deep-garden', 'ink-lavender'];
+const DEFAULT_SITE_PALETTE = 'hill-country';
+const SITE_PALETTE_IDS = ['hill-country', 'live-oak', 'big-bend', 'gulf-rain'];
 const SITE_PALETTE_NAMES = {
-    'meadow-bloom': 'Meadow Bloom',
-    'sunlit-clay': 'Sunlit Clay',
-    'deep-garden': 'Deep Garden',
-    'ink-lavender': 'Ink Lavender'
+    'hill-country': 'Hill Country',
+    'live-oak': 'Live Oak',
+    'big-bend': 'Big Bend',
+    'gulf-rain': 'Gulf Rain'
 };
 
 function getStoredViewMode() {

--- a/style.css
+++ b/style.css
@@ -1,21 +1,21 @@
 :root {
-    /* Howdy Human – Meadow Bloom palette */
-    --background: #f6f4ff;
-    --bg-main-rgb: 246, 244, 255;
-    --text-callout: #fbfafc;
-    --text-primary: #1f2a2a;
-    --text-secondary: #495452;
-    --primary-green: #3a7240; /* Chalet Green */
-    --primary-teal: #51a38b; /* Tradewind */
-    --tertiary-saffron: #f2c14e; /* Saffron */
-    --support-amethyst: #8b6ccf; /* Amethyst */
+    /* Howdy Human – Texas editorial nature palette */
+    --background: #f3eee6;
+    --bg-main-rgb: 243, 238, 230;
+    --text-callout: #fbf7ef;
+    --text-primary: #2b2a26;
+    --text-secondary: #5d5a52;
+    --primary-green: #536b55; /* live oak */
+    --primary-teal: #6f8580; /* dusty blue-green */
+    --tertiary-saffron: #c8ad78; /* wheat */
+    --support-amethyst: #8b654f; /* clay */
     --support-purple: var(--support-amethyst);
-    --support-sky: #d9d4f5; /* Lavender highlight */
-    --support-rose: #f3a6c8;
-    --support-rose-rgb: 243, 166, 200;
-    --support-lavender: #d9d4f5;
-    --card-bg-rgb: 251, 250, 252;
-    --filter-bg-rgb: 244, 240, 255;
+    --support-sky: #d8ddd5; /* limestone sage wash */
+    --support-rose: #b98770; /* muted terracotta */
+    --support-rose-rgb: 185, 135, 112;
+    --support-lavender: #d8ddd5;
+    --card-bg-rgb: 251, 247, 239;
+    --filter-bg-rgb: 236, 229, 216;
 
     /* Interface colors */
     --bg-main: var(--background);
@@ -23,28 +23,27 @@
     --card-bg: var(--text-callout);
     --accent-primary: var(--primary-green);
     --accent-secondary: var(--primary-teal);
-    --accent-primary-rgb: 58, 114, 64;
-    --accent-secondary-rgb: 81, 163, 139;
-    --support-sky-rgb: 217, 212, 245;
-    --support-amethyst-rgb: 139, 108, 207;
-    --support-lavender-rgb: 217, 212, 245;
-    --support-saffron-rgb: 242, 193, 78;
+    --accent-primary-rgb: 83, 107, 85;
+    --accent-secondary-rgb: 111, 133, 128;
+    --support-sky-rgb: 216, 221, 213;
+    --support-amethyst-rgb: 139, 101, 79;
+    --support-lavender-rgb: 216, 221, 213;
+    --support-saffron-rgb: 200, 173, 120;
     --dictionary-fade-start: clamp(360px, 42vh, 560px);
-    --section-label: var(--support-amethyst); /* Section headings */
-    --section-label-rgb: 139, 108, 207;
-    --header-text: #264136; /* General headings */
+    --section-label: #7a6144;
+    --section-label-rgb: 122, 97, 68;
+    --header-text: #3b4137;
     --dark-text: var(--text-secondary);
-    --btn-hover: #2f5c35;
-    --filter-bg: #f4f0ff; /* Soft Prelude wash */
-    --tag-bg: #f7d78a; /* Saffron tags */
-    --card-border: var(--support-amethyst);
+    --btn-hover: #425645;
+    --filter-bg: #ece5d8;
+    --tag-bg: #dfcfaa;
+    --card-border: #c7bda9;
 
     /* Mobile filter sheet layout helpers */
     --filters-sheet-top: 120px;
     --filters-sheet-header-height: 0px;
     --filters-sheet-max-height: calc(100dvh - var(--filters-sheet-top));
 }
-
 body {
     background-color: var(--bg-main);
     background-image:
@@ -1204,7 +1203,7 @@ button, .value-card-toggle, .status-action-button {
     font-weight: 700;
     letter-spacing: 0.01em;
     box-shadow: 0 10px 25px rgba(var(--accent-primary-rgb), 0.2);
-    background: linear-gradient(135deg, var(--accent-primary), #b266ff);
+    background: linear-gradient(135deg, var(--accent-primary), #7b6a53);
 }
 
 .clear-filters-button__icon {
@@ -2313,7 +2312,7 @@ button, .value-card-toggle, .status-action-button {
 }
 
 .reset-btn:hover {
-    background-color: #35b1c3;
+    background-color: #6f8580;
 }
 
 /* Responsive styles */
@@ -2321,20 +2320,22 @@ button, .value-card-toggle, .status-action-button {
 
 /* --- Editorial top-nav + hero refresh (reference screenshot) --- */
 :root {
-    --background: #f4efeb;
-    --bg-main-rgb: 244, 239, 235;
-    --card-bg-rgb: 252, 250, 248;
-    --text-primary: #2f2723;
-    --text-secondary: #4f423c;
-    --accent-primary: #9d4b36;
-    --accent-primary-rgb: 157, 75, 54;
-    --accent-secondary: #8e5845;
-    --accent-secondary-rgb: 142, 88, 69;
-    --header-text: #8d4432;
-    --filter-bg: #f3ece7;
-    --tag-bg: #eee5df;
+    --background: #f3eee6;
+    --bg-main-rgb: 243, 238, 230;
+    --card-bg: #fbf7ef;
+    --card-bg-rgb: 251, 247, 239;
+    --text-primary: #2b2a26;
+    --text-secondary: #5d5a52;
+    --text-secondary-rgb: 93, 90, 82;
+    --accent-primary: #536b55;
+    --accent-primary-rgb: 83, 107, 85;
+    --accent-secondary: #7b6a53;
+    --accent-secondary-rgb: 123, 106, 83;
+    --header-text: #3b4137;
+    --filter-bg: #ece5d8;
+    --tag-bg: #dfcfaa;
+    --support-saffron-rgb: 200, 173, 120;
 }
-
 body {
     background-color: var(--background);
     background-image: none;
@@ -2658,77 +2659,78 @@ body {
     transform: scale(1);
 }
 
-body[data-palette="meadow-bloom"] {
-    --background: #f6f4ff;
-    --bg-main-rgb: 246, 244, 255;
-    --card-bg: #fbfafc;
-    --card-bg-rgb: 251, 250, 252;
-    --text-primary: #1f2a2a;
-    --text-secondary: #495452;
-    --text-secondary-rgb: 73, 84, 82;
-    --accent-primary: #225f45;
-    --accent-primary-rgb: 34, 95, 69;
-    --accent-secondary: #3f8f7a;
-    --accent-secondary-rgb: 63, 143, 122;
-    --header-text: #225f45;
-    --filter-bg: #eeedf8;
-    --tag-bg: #f2c14e;
-    --support-saffron-rgb: 242, 193, 78;
+body[data-palette="hill-country"] {
+    --background: #f3eee6;
+    --bg-main-rgb: 243, 238, 230;
+    --card-bg: #fbf7ef;
+    --card-bg-rgb: 251, 247, 239;
+    --text-primary: #2b2a26;
+    --text-secondary: #5d5a52;
+    --text-secondary-rgb: 93, 90, 82;
+    --accent-primary: #536b55;
+    --accent-primary-rgb: 83, 107, 85;
+    --accent-secondary: #7b6a53;
+    --accent-secondary-rgb: 123, 106, 83;
+    --header-text: #3b4137;
+    --filter-bg: #ece5d8;
+    --tag-bg: #dfcfaa;
+    --support-saffron-rgb: 200, 173, 120;
 }
 
-body[data-palette="sunlit-clay"] {
-    --background: #fff7ed;
-    --bg-main-rgb: 255, 247, 237;
-    --card-bg: #fffcf7;
-    --card-bg-rgb: 255, 252, 247;
-    --text-primary: #2d241c;
-    --text-secondary: #57483d;
-    --text-secondary-rgb: 87, 72, 61;
-    --accent-primary: #8a3f2d;
-    --accent-primary-rgb: 138, 63, 45;
-    --accent-secondary: #246b5a;
-    --accent-secondary-rgb: 36, 107, 90;
-    --header-text: #8a3f2d;
-    --filter-bg: #fff0df;
-    --tag-bg: #e8b84a;
-    --support-saffron-rgb: 232, 184, 74;
+body[data-palette="live-oak"] {
+    --background: #eef0e7;
+    --bg-main-rgb: 238, 240, 231;
+    --card-bg: #fbf8f0;
+    --card-bg-rgb: 251, 248, 240;
+    --text-primary: #282b25;
+    --text-secondary: #575d51;
+    --text-secondary-rgb: 87, 93, 81;
+    --accent-primary: #465c49;
+    --accent-primary-rgb: 70, 92, 73;
+    --accent-secondary: #6f7d68;
+    --accent-secondary-rgb: 111, 125, 104;
+    --header-text: #364437;
+    --filter-bg: #e4e8dc;
+    --tag-bg: #d9cfaa;
+    --support-saffron-rgb: 188, 170, 123;
 }
 
-body[data-palette="deep-garden"] {
-    --background: #18332d;
-    --bg-main-rgb: 24, 51, 45;
-    --card-bg: #24443c;
-    --card-bg-rgb: 36, 68, 60;
-    --text-primary: #fff8ef;
-    --text-secondary: #ddebe5;
-    --text-secondary-rgb: 221, 235, 229;
-    --accent-primary: #9fe0c5;
-    --accent-primary-rgb: 159, 224, 197;
-    --accent-secondary: #f2c14e;
-    --accent-secondary-rgb: 242, 193, 78;
-    --header-text: #fff8ef;
-    --filter-bg: #24443c;
-    --tag-bg: #c9e86a;
-    --support-saffron-rgb: 201, 232, 106;
+body[data-palette="big-bend"] {
+    --background: #f1e8dd;
+    --bg-main-rgb: 241, 232, 221;
+    --card-bg: #fbf4ea;
+    --card-bg-rgb: 251, 244, 234;
+    --text-primary: #302923;
+    --text-secondary: #675a50;
+    --text-secondary-rgb: 103, 90, 80;
+    --accent-primary: #8b654f;
+    --accent-primary-rgb: 139, 101, 79;
+    --accent-secondary: #5f716b;
+    --accent-secondary-rgb: 95, 113, 107;
+    --header-text: #604d3f;
+    --filter-bg: #eadfd1;
+    --tag-bg: #d8bd8c;
+    --support-saffron-rgb: 198, 163, 106;
 }
 
-body[data-palette="ink-lavender"] {
-    --background: #252a44;
-    --bg-main-rgb: 37, 42, 68;
-    --card-bg: #323852;
-    --card-bg-rgb: 50, 56, 82;
-    --text-primary: #fff7f0;
-    --text-secondary: #e8deea;
-    --text-secondary-rgb: 232, 222, 234;
-    --accent-primary: #d6c6ff;
-    --accent-primary-rgb: 214, 198, 255;
-    --accent-secondary: #8ee0d1;
-    --accent-secondary-rgb: 142, 224, 209;
-    --header-text: #fff7f0;
-    --filter-bg: #323852;
-    --tag-bg: #f3a6c8;
-    --support-saffron-rgb: 243, 166, 200;
+body[data-palette="gulf-rain"] {
+    --background: #edf0ec;
+    --bg-main-rgb: 237, 240, 236;
+    --card-bg: #fbf8f1;
+    --card-bg-rgb: 251, 248, 241;
+    --text-primary: #272b2a;
+    --text-secondary: #53605e;
+    --text-secondary-rgb: 83, 96, 94;
+    --accent-primary: #556f6a;
+    --accent-primary-rgb: 85, 111, 106;
+    --accent-secondary: #6f8580;
+    --accent-secondary-rgb: 111, 133, 128;
+    --header-text: #35413f;
+    --filter-bg: #e1e6e1;
+    --tag-bg: #d4c7a2;
+    --support-saffron-rgb: 190, 174, 130;
 }
+
 
 .hero-shell {
     border-radius: 0;
@@ -2866,7 +2868,7 @@ body[data-palette="ink-lavender"] {
 }
 
 .intro-box--editorial .intro-framework-link {
-    color: #1d4ed8;
+    color: #536b55;
     text-decoration-line: underline;
     text-decoration-thickness: 0.08em;
     text-underline-offset: 0.18em;
@@ -2874,5 +2876,5 @@ body[data-palette="ink-lavender"] {
 
 .intro-box--editorial .intro-framework-link:hover,
 .intro-box--editorial .intro-framework-link:focus-visible {
-    color: #153ea8;
+    color: #425645;
 }

--- a/tests/test_homepage_i18n.py
+++ b/tests/test_homepage_i18n.py
@@ -16,7 +16,7 @@ class HomepageI18nTest(unittest.TestCase):
         )
         self.assertIsNotNone(heading)
         self.assertEqual(heading.group(1), "Browse by category")
-        asset_version = "menu-palette-20260617"
+        asset_version = "texas-editorial-20260707"
         self.assertIn(f'href="style.css?v={asset_version}"', html)
         self.assertIn(f'src="script.js?v={asset_version}"', html)
 

--- a/values/acceptance/index.html
+++ b/values/acceptance/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/accountability/index.html
+++ b/values/accountability/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/achievement/index.html
+++ b/values/achievement/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/action/index.html
+++ b/values/action/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/adventure/index.html
+++ b/values/adventure/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/advocacy/index.html
+++ b/values/advocacy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/ambiguity/index.html
+++ b/values/ambiguity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/ambition/index.html
+++ b/values/ambition/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/appreciation/index.html
+++ b/values/appreciation/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/approachability/index.html
+++ b/values/approachability/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/authenticity/index.html
+++ b/values/authenticity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/balance/index.html
+++ b/values/balance/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/beauty/index.html
+++ b/values/beauty/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/benevolence/index.html
+++ b/values/benevolence/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/boldness/index.html
+++ b/values/boldness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/bravery/index.html
+++ b/values/bravery/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/camaraderie/index.html
+++ b/values/camaraderie/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/capitalism/index.html
+++ b/values/capitalism/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/caring/index.html
+++ b/values/caring/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/aspirations/index.html
+++ b/values/category/aspirations/index.html
@@ -130,23 +130,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/core-values/index.html
+++ b/values/category/core-values/index.html
@@ -184,23 +184,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/growth/index.html
+++ b/values/category/growth/index.html
@@ -178,23 +178,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/interpersonal/index.html
+++ b/values/category/interpersonal/index.html
@@ -250,23 +250,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/mindset/index.html
+++ b/values/category/mindset/index.html
@@ -172,23 +172,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/personal/index.html
+++ b/values/category/personal/index.html
@@ -202,23 +202,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/category/social/index.html
+++ b/values/category/social/index.html
@@ -160,23 +160,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/celebration/index.html
+++ b/values/celebration/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/challenge/index.html
+++ b/values/challenge/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/charisma/index.html
+++ b/values/charisma/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/choice/index.html
+++ b/values/choice/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/clarity/index.html
+++ b/values/clarity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/collaboration/index.html
+++ b/values/collaboration/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/comedy/index.html
+++ b/values/comedy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/comfort/index.html
+++ b/values/comfort/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/commitment/index.html
+++ b/values/commitment/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/communication/index.html
+++ b/values/communication/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/community/index.html
+++ b/values/community/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/compassion/index.html
+++ b/values/compassion/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/confidence/index.html
+++ b/values/confidence/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/connection/index.html
+++ b/values/connection/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/cooperation/index.html
+++ b/values/cooperation/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/courage/index.html
+++ b/values/courage/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/craftsmanship/index.html
+++ b/values/craftsmanship/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/creativity/index.html
+++ b/values/creativity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/curiosity/index.html
+++ b/values/curiosity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/determination/index.html
+++ b/values/determination/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/discipline/index.html
+++ b/values/discipline/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/effectiveness/index.html
+++ b/values/effectiveness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/empathy/index.html
+++ b/values/empathy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/equality/index.html
+++ b/values/equality/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/experiment/index.html
+++ b/values/experiment/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/exploration/index.html
+++ b/values/exploration/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/fairness/index.html
+++ b/values/fairness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/family/index.html
+++ b/values/family/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/fine-art/index.html
+++ b/values/fine-art/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/flexibility/index.html
+++ b/values/flexibility/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/foresight/index.html
+++ b/values/foresight/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/forgiveness/index.html
+++ b/values/forgiveness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/freedom/index.html
+++ b/values/freedom/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/friendship/index.html
+++ b/values/friendship/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/fun/index.html
+++ b/values/fun/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/grace/index.html
+++ b/values/grace/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/gratitude/index.html
+++ b/values/gratitude/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/growth/index.html
+++ b/values/growth/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/happiness/index.html
+++ b/values/happiness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/health/index.html
+++ b/values/health/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/history/index.html
+++ b/values/history/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/honesty/index.html
+++ b/values/honesty/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/honor/index.html
+++ b/values/honor/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/hope/index.html
+++ b/values/hope/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/humility/index.html
+++ b/values/humility/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/humor/index.html
+++ b/values/humor/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/imagination/index.html
+++ b/values/imagination/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/impact/index.html
+++ b/values/impact/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/independence/index.html
+++ b/values/independence/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/initiative/index.html
+++ b/values/initiative/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/inner-peace/index.html
+++ b/values/inner-peace/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/innovation/index.html
+++ b/values/innovation/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/integrity/index.html
+++ b/values/integrity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/intuition/index.html
+++ b/values/intuition/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/justice/index.html
+++ b/values/justice/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/kindness/index.html
+++ b/values/kindness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/knowledge/index.html
+++ b/values/knowledge/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/laughter/index.html
+++ b/values/laughter/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/leadership/index.html
+++ b/values/leadership/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/learning/index.html
+++ b/values/learning/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/legacy/index.html
+++ b/values/legacy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/love/index.html
+++ b/values/love/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/loyalty/index.html
+++ b/values/loyalty/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/luxury/index.html
+++ b/values/luxury/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/meditation/index.html
+++ b/values/meditation/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/mental-health/index.html
+++ b/values/mental-health/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/mentorship/index.html
+++ b/values/mentorship/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/mindfulness/index.html
+++ b/values/mindfulness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/mission/index.html
+++ b/values/mission/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/money/index.html
+++ b/values/money/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/movement/index.html
+++ b/values/movement/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/networking/index.html
+++ b/values/networking/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/open-mindedness/index.html
+++ b/values/open-mindedness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/optimism/index.html
+++ b/values/optimism/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/partnership/index.html
+++ b/values/partnership/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/patience/index.html
+++ b/values/patience/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/perseverance/index.html
+++ b/values/perseverance/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/philanthropy/index.html
+++ b/values/philanthropy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/physical-health/index.html
+++ b/values/physical-health/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/piety/index.html
+++ b/values/piety/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/positive-attitude/index.html
+++ b/values/positive-attitude/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/pragmatism/index.html
+++ b/values/pragmatism/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/presence/index.html
+++ b/values/presence/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/professionalism/index.html
+++ b/values/professionalism/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/purpose/index.html
+++ b/values/purpose/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/quality/index.html
+++ b/values/quality/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/recognition/index.html
+++ b/values/recognition/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/recovery/index.html
+++ b/values/recovery/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/reliability/index.html
+++ b/values/reliability/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/representation/index.html
+++ b/values/representation/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/resilience/index.html
+++ b/values/resilience/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/respect/index.html
+++ b/values/respect/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/responsibility/index.html
+++ b/values/responsibility/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/romance/index.html
+++ b/values/romance/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/safety/index.html
+++ b/values/safety/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-actualization/index.html
+++ b/values/self-actualization/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-awareness/index.html
+++ b/values/self-awareness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-care/index.html
+++ b/values/self-care/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-compassion/index.html
+++ b/values/self-compassion/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-control/index.html
+++ b/values/self-control/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/self-expression/index.html
+++ b/values/self-expression/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/selflessness/index.html
+++ b/values/selflessness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/service/index.html
+++ b/values/service/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/sovereignty/index.html
+++ b/values/sovereignty/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/spirituality/index.html
+++ b/values/spirituality/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/sports/index.html
+++ b/values/sports/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/sportsmanship/index.html
+++ b/values/sportsmanship/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/stability/index.html
+++ b/values/stability/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/stewardship/index.html
+++ b/values/stewardship/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/stillness/index.html
+++ b/values/stillness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/strategy/index.html
+++ b/values/strategy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/sustainability/index.html
+++ b/values/sustainability/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/synergy/index.html
+++ b/values/synergy/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/teaching/index.html
+++ b/values/teaching/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/teamwork/index.html
+++ b/values/teamwork/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/technology/index.html
+++ b/values/technology/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/thoughtfulness/index.html
+++ b/values/thoughtfulness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/tolerance/index.html
+++ b/values/tolerance/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/trust/index.html
+++ b/values/trust/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/truth/index.html
+++ b/values/truth/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/unity/index.html
+++ b/values/unity/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/versatility/index.html
+++ b/values/versatility/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/vision/index.html
+++ b/values/vision/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/willingness/index.html
+++ b/values/willingness/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/wisdom/index.html
+++ b/values/wisdom/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/values/work-ethic/index.html
+++ b/values/work-ethic/index.html
@@ -93,23 +93,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/accept/index.html
+++ b/verbs/accept/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/accommodate/index.html
+++ b/verbs/accommodate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/accomplish/index.html
+++ b/verbs/accomplish/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/achieve/index.html
+++ b/verbs/achieve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/acknowledge/index.html
+++ b/verbs/acknowledge/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/acquire/index.html
+++ b/verbs/acquire/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/act/index.html
+++ b/verbs/act/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/adapt/index.html
+++ b/verbs/adapt/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/adhere/index.html
+++ b/verbs/adhere/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/adjust/index.html
+++ b/verbs/adjust/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/admire/index.html
+++ b/verbs/admire/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/admit/index.html
+++ b/verbs/admit/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/adore/index.html
+++ b/verbs/adore/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/advance/index.html
+++ b/verbs/advance/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/advocate/index.html
+++ b/verbs/advocate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/aid/index.html
+++ b/verbs/aid/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/align/index.html
+++ b/verbs/align/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/allocate/index.html
+++ b/verbs/allocate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/allow/index.html
+++ b/verbs/allow/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/ally/index.html
+++ b/verbs/ally/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/alter/index.html
+++ b/verbs/alter/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/amuse/index.html
+++ b/verbs/amuse/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/analyze/index.html
+++ b/verbs/analyze/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/anticipate/index.html
+++ b/verbs/anticipate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/apply/index.html
+++ b/verbs/apply/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/appreciate/index.html
+++ b/verbs/appreciate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/aspire/index.html
+++ b/verbs/aspire/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/assist/index.html
+++ b/verbs/assist/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/associate/index.html
+++ b/verbs/associate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/assume/index.html
+++ b/verbs/assume/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/attain/index.html
+++ b/verbs/attain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/attempt/index.html
+++ b/verbs/attempt/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/attend/index.html
+++ b/verbs/attend/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/balance/index.html
+++ b/verbs/balance/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/believe/index.html
+++ b/verbs/believe/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/bond/index.html
+++ b/verbs/bond/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/build/index.html
+++ b/verbs/build/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/calm/index.html
+++ b/verbs/calm/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/care/index.html
+++ b/verbs/care/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/celebrate/index.html
+++ b/verbs/celebrate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/challenge/index.html
+++ b/verbs/challenge/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/change/index.html
+++ b/verbs/change/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/cherish/index.html
+++ b/verbs/cherish/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/choose/index.html
+++ b/verbs/choose/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/clarify/index.html
+++ b/verbs/clarify/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/collaborate/index.html
+++ b/verbs/collaborate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/combine/index.html
+++ b/verbs/combine/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/comfort/index.html
+++ b/verbs/comfort/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/commit/index.html
+++ b/verbs/commit/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/communicate/index.html
+++ b/verbs/communicate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/compete/index.html
+++ b/verbs/compete/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/complete/index.html
+++ b/verbs/complete/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/compose/index.html
+++ b/verbs/compose/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/comprehend/index.html
+++ b/verbs/comprehend/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/conceive/index.html
+++ b/verbs/conceive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/conceptualize/index.html
+++ b/verbs/conceptualize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/conduct/index.html
+++ b/verbs/conduct/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/confide/index.html
+++ b/verbs/confide/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/confront/index.html
+++ b/verbs/confront/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/connect/index.html
+++ b/verbs/connect/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/conserve/index.html
+++ b/verbs/conserve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/consider/index.html
+++ b/verbs/consider/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/contemplate/index.html
+++ b/verbs/contemplate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/continue/index.html
+++ b/verbs/continue/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/contribute/index.html
+++ b/verbs/contribute/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/control/index.html
+++ b/verbs/control/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/cooperate/index.html
+++ b/verbs/cooperate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/coordinate/index.html
+++ b/verbs/coordinate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/craft/index.html
+++ b/verbs/craft/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/create/index.html
+++ b/verbs/create/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/cultivate/index.html
+++ b/verbs/cultivate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/decide/index.html
+++ b/verbs/decide/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/dedicate/index.html
+++ b/verbs/dedicate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/defend/index.html
+++ b/verbs/defend/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/define/index.html
+++ b/verbs/define/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/delight/index.html
+++ b/verbs/delight/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/deliver/index.html
+++ b/verbs/deliver/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/demonstrate/index.html
+++ b/verbs/demonstrate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/design/index.html
+++ b/verbs/design/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/determine/index.html
+++ b/verbs/determine/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/develop/index.html
+++ b/verbs/develop/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/direct/index.html
+++ b/verbs/direct/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/discern/index.html
+++ b/verbs/discern/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/discover/index.html
+++ b/verbs/discover/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/display/index.html
+++ b/verbs/display/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/distribute/index.html
+++ b/verbs/distribute/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/drive/index.html
+++ b/verbs/drive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/earn/index.html
+++ b/verbs/earn/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/embody/index.html
+++ b/verbs/embody/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/embrace/index.html
+++ b/verbs/embrace/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/endeavor/index.html
+++ b/verbs/endeavor/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/endure/index.html
+++ b/verbs/endure/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/engage/index.html
+++ b/verbs/engage/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/enjoy/index.html
+++ b/verbs/enjoy/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/ensure/index.html
+++ b/verbs/ensure/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/entertain/index.html
+++ b/verbs/entertain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/envision/index.html
+++ b/verbs/envision/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/equalize/index.html
+++ b/verbs/equalize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/establish/index.html
+++ b/verbs/establish/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/evaluate/index.html
+++ b/verbs/evaluate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/examine/index.html
+++ b/verbs/examine/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/execute/index.html
+++ b/verbs/execute/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/exercise/index.html
+++ b/verbs/exercise/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/exhibit/index.html
+++ b/verbs/exhibit/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/expect/index.html
+++ b/verbs/expect/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/experience/index.html
+++ b/verbs/experience/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/explain/index.html
+++ b/verbs/explain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/explore/index.html
+++ b/verbs/explore/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/express/index.html
+++ b/verbs/express/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/extend/index.html
+++ b/verbs/extend/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/face/index.html
+++ b/verbs/face/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/feel/index.html
+++ b/verbs/feel/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/find/index.html
+++ b/verbs/find/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/focus/index.html
+++ b/verbs/focus/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/follow/index.html
+++ b/verbs/follow/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/foresee/index.html
+++ b/verbs/foresee/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/forgive/index.html
+++ b/verbs/forgive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/formulate/index.html
+++ b/verbs/formulate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/fulfill/index.html
+++ b/verbs/fulfill/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/give/index.html
+++ b/verbs/give/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/govern/index.html
+++ b/verbs/govern/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/grow/index.html
+++ b/verbs/grow/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/guard/index.html
+++ b/verbs/guard/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/guide/index.html
+++ b/verbs/guide/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/harmonize/index.html
+++ b/verbs/harmonize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/heal/index.html
+++ b/verbs/heal/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/help/index.html
+++ b/verbs/help/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/honor/index.html
+++ b/verbs/honor/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/imagine/index.html
+++ b/verbs/imagine/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/implement/index.html
+++ b/verbs/implement/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/improve/index.html
+++ b/verbs/improve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/include/index.html
+++ b/verbs/include/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/influence/index.html
+++ b/verbs/influence/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/initiate/index.html
+++ b/verbs/initiate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/innovate/index.html
+++ b/verbs/innovate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/inspire/index.html
+++ b/verbs/inspire/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/integrate/index.html
+++ b/verbs/integrate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/interpret/index.html
+++ b/verbs/interpret/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/introduce/index.html
+++ b/verbs/introduce/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/invent/index.html
+++ b/verbs/invent/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/invest/index.html
+++ b/verbs/invest/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/investigate/index.html
+++ b/verbs/investigate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/join/index.html
+++ b/verbs/join/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/joke/index.html
+++ b/verbs/joke/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/journey/index.html
+++ b/verbs/journey/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/judge/index.html
+++ b/verbs/judge/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/know/index.html
+++ b/verbs/know/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/laugh/index.html
+++ b/verbs/laugh/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/lead/index.html
+++ b/verbs/lead/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/learn/index.html
+++ b/verbs/learn/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/lighten/index.html
+++ b/verbs/lighten/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/link/index.html
+++ b/verbs/link/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/listen/index.html
+++ b/verbs/listen/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/live/index.html
+++ b/verbs/live/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/look-forward/index.html
+++ b/verbs/look-forward/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/love/index.html
+++ b/verbs/love/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/maintain/index.html
+++ b/verbs/maintain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/manage/index.html
+++ b/verbs/manage/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/manifest/index.html
+++ b/verbs/manifest/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/master/index.html
+++ b/verbs/master/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/mentor/index.html
+++ b/verbs/mentor/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/merge/index.html
+++ b/verbs/merge/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/moderate/index.html
+++ b/verbs/moderate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/modify/index.html
+++ b/verbs/modify/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/monitor/index.html
+++ b/verbs/monitor/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/motivate/index.html
+++ b/verbs/motivate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/move/index.html
+++ b/verbs/move/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/notice/index.html
+++ b/verbs/notice/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/nourish/index.html
+++ b/verbs/nourish/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/nurture/index.html
+++ b/verbs/nurture/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/observe/index.html
+++ b/verbs/observe/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/offer/index.html
+++ b/verbs/offer/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/originate/index.html
+++ b/verbs/originate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/overcome/index.html
+++ b/verbs/overcome/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/own/index.html
+++ b/verbs/own/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/participate/index.html
+++ b/verbs/participate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/partner/index.html
+++ b/verbs/partner/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/perceive/index.html
+++ b/verbs/perceive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/perform/index.html
+++ b/verbs/perform/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/permit/index.html
+++ b/verbs/permit/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/persist/index.html
+++ b/verbs/persist/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/pioneer/index.html
+++ b/verbs/pioneer/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/plan/index.html
+++ b/verbs/plan/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/play/index.html
+++ b/verbs/play/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/practice/index.html
+++ b/verbs/practice/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/praise/index.html
+++ b/verbs/praise/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/preserve/index.html
+++ b/verbs/preserve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/prioritize/index.html
+++ b/verbs/prioritize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/probe/index.html
+++ b/verbs/probe/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/produce/index.html
+++ b/verbs/produce/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/promote/index.html
+++ b/verbs/promote/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/proportion/index.html
+++ b/verbs/proportion/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/protect/index.html
+++ b/verbs/protect/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/provide/index.html
+++ b/verbs/provide/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/pursue/index.html
+++ b/verbs/pursue/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/push/index.html
+++ b/verbs/push/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/question/index.html
+++ b/verbs/question/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/reach/index.html
+++ b/verbs/reach/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/realize/index.html
+++ b/verbs/realize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/receive/index.html
+++ b/verbs/receive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/recognize/index.html
+++ b/verbs/recognize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/reflect/index.html
+++ b/verbs/reflect/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/regulate/index.html
+++ b/verbs/regulate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/relate/index.html
+++ b/verbs/relate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/release/index.html
+++ b/verbs/release/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/rely/index.html
+++ b/verbs/rely/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/remain/index.html
+++ b/verbs/remain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/represent/index.html
+++ b/verbs/represent/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/research/index.html
+++ b/verbs/research/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/resolve/index.html
+++ b/verbs/resolve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/respect/index.html
+++ b/verbs/respect/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/respond/index.html
+++ b/verbs/respond/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/rest/index.html
+++ b/verbs/rest/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/restore/index.html
+++ b/verbs/restore/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/reveal/index.html
+++ b/verbs/reveal/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/revolutionize/index.html
+++ b/verbs/revolutionize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/risk/index.html
+++ b/verbs/risk/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/savor/index.html
+++ b/verbs/savor/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/secure/index.html
+++ b/verbs/secure/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/seek/index.html
+++ b/verbs/seek/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/select/index.html
+++ b/verbs/select/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/sense/index.html
+++ b/verbs/sense/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/serve/index.html
+++ b/verbs/serve/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/shape/index.html
+++ b/verbs/shape/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/share/index.html
+++ b/verbs/share/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/shift/index.html
+++ b/verbs/shift/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/show/index.html
+++ b/verbs/show/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/speak/index.html
+++ b/verbs/speak/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/stand/index.html
+++ b/verbs/stand/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/strengthen/index.html
+++ b/verbs/strengthen/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/strive/index.html
+++ b/verbs/strive/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/study/index.html
+++ b/verbs/study/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/support/index.html
+++ b/verbs/support/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/sustain/index.html
+++ b/verbs/sustain/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/teach/index.html
+++ b/verbs/teach/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/test/index.html
+++ b/verbs/test/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/think/index.html
+++ b/verbs/think/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/tolerate/index.html
+++ b/verbs/tolerate/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/train/index.html
+++ b/verbs/train/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/transform/index.html
+++ b/verbs/transform/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/treasure/index.html
+++ b/verbs/treasure/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/treat/index.html
+++ b/verbs/treat/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/trust/index.html
+++ b/verbs/trust/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/understand/index.html
+++ b/verbs/understand/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/undertake/index.html
+++ b/verbs/undertake/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/unite/index.html
+++ b/verbs/unite/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/uphold/index.html
+++ b/verbs/uphold/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/utilize/index.html
+++ b/verbs/utilize/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/value/index.html
+++ b/verbs/value/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/venture/index.html
+++ b/verbs/venture/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/verify/index.html
+++ b/verbs/verify/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/welcome/index.html
+++ b/verbs/welcome/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/withstand/index.html
+++ b/verbs/withstand/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/work/index.html
+++ b/verbs/work/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>

--- a/verbs/yield/index.html
+++ b/verbs/yield/index.html
@@ -46,23 +46,23 @@
 }
   </script>
   <style>
-    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #1f2a2a; background: #edf4ef; }
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; line-height: 1.55; margin: 0; color: #2b2a26; background: #f3eee6; }
     main { max-width: 760px; margin: 0 auto; padding: 2rem 1.25rem 3rem; }
-    article { background: #fff; border: 1px solid #d8e3db; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(0,0,0,.05); }
-    h1 { margin-top: 0; line-height: 1.2; }
-    h2 { margin-top: 1.5rem; font-size: 1.1rem; }
+    article { background: #fbf7ef; border: 1px solid #c7bda9; border-radius: 16px; padding: 1.5rem; box-shadow: 0 8px 24px rgba(43,42,38,.06); }
+    h1 { margin-top: 0; line-height: 1.2; color: #3b4137; }
+    h2 { margin-top: 1.5rem; font-size: 1.1rem; color: #3b4137; }
     p { margin: .65rem 0; }
     ul { margin: .5rem 0 0; padding-left: 1.1rem; }
-    a { color: #225f45; }
-    .meta { color: #495452; font-size: .95rem; }
-    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #5f6f68; font-size: .9rem; }
-    .breadcrumbs a { color: #225f45; text-decoration: none; }
+    a { color: #536b55; }
+    .meta { color: #5d5a52; font-size: .95rem; }
+    .breadcrumbs { display: flex; flex-wrap: wrap; align-items: center; gap: .4rem; margin-bottom: 1rem; color: #706b60; font-size: .9rem; }
+    .breadcrumbs a { color: #536b55; text-decoration: none; }
     .breadcrumbs a:hover { text-decoration: underline; }
-    .chip { display: inline-block; border: 1px solid #b8c8be; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #234834; }
+    .chip { display: inline-block; border: 1px solid #c7bda9; border-radius: 999px; padding: .2rem .65rem; margin: .2rem .35rem .2rem 0; font-size: .85rem; text-decoration: none; color: #3f513f; background: #ece5d8; }
     .category-value-list { display: grid; gap: .75rem; padding-left: 0; list-style: none; }
-    .category-value-list li { border-top: 1px solid #e5eee8; padding-top: .75rem; }
+    .category-value-list li { border-top: 1px solid #ded5c5; padding-top: .75rem; }
     .category-value-list a { display: block; font-weight: 700; }
-    .category-value-list span { display: block; margin-top: .2rem; color: #495452; }
+    .category-value-list span { display: block; margin-top: .2rem; color: #5d5a52; }
   </style>
 </head>
 <body>


### PR DESCRIPTION
### Motivation
- Replace the site's current bright, inconsistent palette with a restrained, editorial, nature-inspired system that reads calm, grounded, and dignified rather than juvenile or startup-y.
- Favor warm off-whites over stark white, charcoal for copy instead of pure black, and muted, earthy accents (clay, wheat, sage, dusty blue, live-oak green) so every color feels rooted in nature and high-quality print/park signage references.
- Provide a coherent palette selection and rollout so generated pages, the homepage, and standalone pages share the same tonal system.

### Description
- Reworked the global CSS variables in `style.css` (root and palette blocks) to a new Texas editorial nature palette and added four landscape-themed palettes: `hill-country`, `live-oak`, `big-bend`, and `gulf-rain` with updated RGB tokens and interface variables.  
- Updated the site menu palette UI and asset cache-busting tokens in `index.html` (selector labels, swatches) and changed the stylesheet/script version query to `texas-editorial-20260707`.  
- Updated runtime defaults and IDs in `script.js` (`DEFAULT_SITE_PALETTE`, `SITE_PALETTE_IDS`, `SITE_PALETTE_NAMES`) so stored and selected palettes use the new names.  
- Updated the SEO page template in `generate_seo_pages.py` and regenerated the static pages and `sitemap.xml`, and propagated the new palette styling into generated value/category/verb pages plus standalone pages like `404.html` and `values-in-action-audit/index.html` so the visual system is applied consistently across the site.

### Testing
- ✅ Ran `python3 generate_seo_pages.py` and it completed, regenerating value/category/verb pages and refreshing `sitemap.xml`.  
- ✅ Ran the test suite with `python3 -m pytest` and all tests passed locally (`5 passed`).  
- ⚠️ Attempted `npx playwright --version` for automated browser screenshots, but Playwright could not be installed from the npm registry in this environment (npm returned a `403 Forbidden`), so no browser-render screenshots were captured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d378e2f98832287b6020593c3565a)