### PR TITLE
Use purple category headings in Electric Bloom

### DIFF
--- a/style.css
+++ b/style.css
@@ -2198,6 +2198,7 @@ button, .value-card-toggle, .status-action-button {
     margin: 0 0 0.35rem;
     font-size: 1.1rem;
     font-weight: 700;
+    color: var(--category-heading, var(--text-main));
 }
 
 .seo-category-card p {
@@ -2694,6 +2695,7 @@ body[data-palette="electric-bloom"] {
     --accent-secondary: #6b4d7e;
     --accent-secondary-rgb: 107, 77, 126;
     --alpha-nav-link: #6b4d7e;
+    --category-heading: #6b4d7e;
     --header-text: #20182d;
     --filter-bg: #efdfe1;
     --filter-bg-rgb: 239, 223, 225;


### PR DESCRIPTION
## Summary
- render Electric Bloom category-card headings in Dusty Purple instead of Deep Ink
- keep the supporting category copy in Deep Ink for readability

## Validation
- `python3 -m unittest discover -s tests -v` (5 tests passed)
- `node --check script.js`
- verified the rendered Growth heading resolves to `rgb(107, 77, 126)`
- no relevant browser console errors