### PR TITLE
Keep active verb filter visible while scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=sticky-filter-20260713">
+    <link rel="stylesheet" href="style.css?v=sticky-stack-20260713">
 </head>
 <body>
     <noscript>
@@ -1461,6 +1461,6 @@
         </footer>
     </div>
 
-    <script src="script.js?v=sticky-filter-20260713"></script>
+    <script src="script.js?v=sticky-stack-20260713"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=palette-range-20260713">
+    <link rel="stylesheet" href="style.css?v=sticky-filter-20260713">
 </head>
 <body>
     <noscript>
@@ -1461,6 +1461,6 @@
         </footer>
     </div>
 
-    <script src="script.js?v=palette-range-20260713"></script>
+    <script src="script.js?v=sticky-filter-20260713"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -977,6 +977,7 @@ function clearSearchTerm({ updateUI = true } = {}) {
 
 // Scroll spy observer reference
 let scrollSpyObserver;
+let alphaNavResizeObserver;
 
 // Helper to calculate the offset for alpha navigation
 function getAlphaNavOffset() {
@@ -1006,6 +1007,27 @@ function getAlphaNavOffset() {
     }
 
     return offset;
+}
+
+function setupStickyStacking() {
+    if (!alphaNav) return;
+
+    const updateAlphaNavStickyOffset = () => {
+        document.documentElement.style.setProperty(
+            '--alpha-nav-sticky-offset',
+            `${Math.ceil(alphaNav.getBoundingClientRect().height)}px`
+        );
+    };
+
+    updateAlphaNavStickyOffset();
+
+    if ('ResizeObserver' in window) {
+        alphaNavResizeObserver?.disconnect();
+        alphaNavResizeObserver = new ResizeObserver(updateAlphaNavStickyOffset);
+        alphaNavResizeObserver.observe(alphaNav);
+    } else {
+        window.addEventListener('resize', updateAlphaNavStickyOffset);
+    }
 }
 
 function clampAlphaNavTogglePosition(left, top) {
@@ -1309,6 +1331,7 @@ document.addEventListener('DOMContentLoaded', function() {
         valuesCount = document.getElementById('valuesCount');
         alphaNav = document.getElementById('alphaNav');
         alphaNavList = alphaNav ? alphaNav.querySelector('.alpha-nav-list') : null;
+        setupStickyStacking();
         alphaNavToggle = document.getElementById('alphaNavToggle');
         alphaNavOverlay = document.getElementById('alphaNavOverlay');
         alphaNavOverlayList = document.getElementById('alphaNavOverlayList');

--- a/style.css
+++ b/style.css
@@ -483,7 +483,7 @@ button, .value-card-toggle, .status-action-button {
 
 .verb-filter-header {
     position: sticky;
-    top: 0;
+    top: var(--alpha-nav-sticky-offset, 0px);
     z-index: 70;
     background-color: var(--filter-bg);
     border: 1px solid rgba(var(--support-amethyst-rgb), 0.12);

--- a/style.css
+++ b/style.css
@@ -482,12 +482,16 @@ button, .value-card-toggle, .status-action-button {
 }
 
 .verb-filter-header {
+    position: sticky;
+    top: 0;
+    z-index: 70;
     background-color: var(--filter-bg);
     border: 1px solid rgba(var(--support-amethyst-rgb), 0.12);
     border-radius: 16px;
     padding: 1rem 1.25rem;
     margin-bottom: 1.5rem;
-    box-shadow: 0 10px 24px rgba(var(--support-amethyst-rgb), 0.08);
+    box-shadow: 0 12px 30px rgba(var(--support-amethyst-rgb), 0.16);
+    backdrop-filter: blur(14px);
 }
 
 .verb-filter-header__top {
@@ -537,6 +541,23 @@ button, .value-card-toggle, .status-action-button {
     margin-top: 0.5rem;
     font-size: 1rem;
     color: var(--text-secondary);
+}
+
+@media (max-width: 640px) {
+    .verb-filter-header {
+        border-radius: 0 0 12px 12px;
+        padding: 0.75rem 1rem;
+        margin-inline: -1rem;
+    }
+
+    .verb-filter-header__top {
+        gap: 0.5rem;
+    }
+
+    .verb-filter-description {
+        margin-top: 0.35rem;
+        font-size: 0.9rem;
+    }
 }
 
 .filter-column {

--- a/tests/test_homepage_i18n.py
+++ b/tests/test_homepage_i18n.py
@@ -16,9 +16,18 @@ class HomepageI18nTest(unittest.TestCase):
         )
         self.assertIsNotNone(heading)
         self.assertEqual(heading.group(1), "Browse by category")
-        asset_version = "palette-range-20260713"
+        asset_version = "sticky-filter-20260713"
         self.assertIn(f'href="style.css?v={asset_version}"', html)
         self.assertIn(f'src="script.js?v={asset_version}"', html)
+
+    def test_active_verb_filter_banner_stays_visible_while_scrolling(self):
+        css = (ROOT / "style.css").read_text(encoding="utf-8")
+
+        sticky_banner = re.search(r"\.verb-filter-header\s*\{([^}]+)\}", css)
+        self.assertIsNotNone(sticky_banner)
+        declarations = sticky_banner.group(1)
+        self.assertIn("position: sticky", declarations)
+        self.assertIn("top: 0", declarations)
 
 
 if __name__ == "__main__":

--- a/tests/test_homepage_i18n.py
+++ b/tests/test_homepage_i18n.py
@@ -16,7 +16,7 @@ class HomepageI18nTest(unittest.TestCase):
         )
         self.assertIsNotNone(heading)
         self.assertEqual(heading.group(1), "Browse by category")
-        asset_version = "sticky-filter-20260713"
+        asset_version = "sticky-stack-20260713"
         self.assertIn(f'href="style.css?v={asset_version}"', html)
         self.assertIn(f'src="script.js?v={asset_version}"', html)
 
@@ -27,7 +27,11 @@ class HomepageI18nTest(unittest.TestCase):
         self.assertIsNotNone(sticky_banner)
         declarations = sticky_banner.group(1)
         self.assertIn("position: sticky", declarations)
-        self.assertIn("top: 0", declarations)
+        self.assertIn("top: var(--alpha-nav-sticky-offset, 0px)", declarations)
+
+        script = (ROOT / "script.js").read_text(encoding="utf-8")
+        self.assertIn("--alpha-nav-sticky-offset", script)
+        self.assertIn("ResizeObserver", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- keep the active verb filter banner pinned while browsing filtered values
- stack it beneath the sticky A-Z navigation using the navigation's measured height
- update the offset automatically when the A-Z bar resizes across desktop and phone layouts
- refresh asset versions and add regression coverage for the coordinated sticky position

## Verification
- `python3 -m unittest discover -s tests -v`
- `node --check script.js`
- desktop: A-Z height 64px, banner top 64px, zero overlap
- phone: A-Z height 103px, banner top 103px, zero overlap
- alphabet links remain visible, no horizontal overflow, and no browser warnings or errors