### PR TITLE
Add varied site color palettes

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=value-hierarchy-20260713">
+    <link rel="stylesheet" href="style.css?v=tag-contrast-20260713">
 </head>
 <body>
     <noscript>
@@ -1461,6 +1461,6 @@
         </footer>
     </div>
 
-    <script src="script.js?v=value-hierarchy-20260713"></script>
+    <script src="script.js?v=tag-contrast-20260713"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -38,6 +38,8 @@
     --related-values-accent-rgb: var(--accent-secondary-rgb);
     --value-title-accent: var(--support-purple);
     --value-description-color: var(--accent-primary);
+    --tag-hover-text: var(--support-purple);
+    --tag-selected-text: var(--text-callout);
     --header-text: #3b4137;
     --dark-text: var(--text-secondary);
     --btn-hover: #425645;
@@ -458,7 +460,7 @@ button, .value-card-toggle, .status-action-button {
 
 .tag:hover {
     background-color: var(--support-sky);
-    color: var(--support-purple);
+    color: var(--tag-hover-text);
     border-color: rgba(var(--support-amethyst-rgb), 0.24);
     box-shadow: 0 6px 14px rgba(var(--support-amethyst-rgb), 0.12);
 }
@@ -466,7 +468,7 @@ button, .value-card-toggle, .status-action-button {
 .tag.selected,
 .tag.is-selected-verb {
     background: linear-gradient(135deg, rgba(var(--support-amethyst-rgb), 0.92), rgba(var(--support-sky-rgb), 0.9));
-    color: var(--text-callout);
+    color: var(--tag-selected-text);
     border-color: rgba(var(--support-amethyst-rgb), 0.32);
     box-shadow: 0 6px 16px rgba(var(--support-amethyst-rgb), 0.18);
 }
@@ -2715,7 +2717,15 @@ body[data-palette="hill-country"] {
     --header-text: #3b4137;
     --filter-bg: #ece5d8;
     --tag-bg: #dfcfaa;
+    --support-sky: #d8ddd5;
     --support-saffron-rgb: 200, 173, 120;
+    --tag-hover-text: var(--header-text);
+    --value-title-accent: var(--support-purple);
+    --value-detail-accent: var(--accent-primary);
+    --value-detail-accent-rgb: var(--accent-primary-rgb);
+    --related-values-accent: var(--accent-secondary);
+    --related-values-accent-rgb: var(--accent-secondary-rgb);
+    --value-description-color: var(--accent-primary);
 }
 
 body[data-palette="electric-bloom"] {
@@ -2745,6 +2755,7 @@ body[data-palette="electric-bloom"] {
     --support-purple: #c996f2;
     --support-amethyst-rgb: 201, 150, 242;
     --support-lavender-rgb: 201, 150, 242;
+    --support-sky: #9fd9e0;
     --support-sky-rgb: 159, 217, 224;
     --support-rose-rgb: 255, 143, 157;
     --support-saffron-rgb: 185, 223, 207;
@@ -2756,6 +2767,8 @@ body[data-palette="electric-bloom"] {
     --related-values-accent-rgb: var(--accent-primary-rgb);
     --value-title-accent: var(--accent-secondary);
     --value-description-color: var(--text-secondary);
+    --tag-hover-text: var(--header-text);
+    --tag-selected-text: var(--header-text);
     --btn-hover: #913d36;
 }
 
@@ -2789,11 +2802,20 @@ body[data-palette="blue-hour"] {
     --support-purple: #b093cf;
     --support-amethyst-rgb: 176, 147, 207;
     --support-lavender-rgb: 243, 236, 251;
+    --support-sky: #bee0ff;
     --support-sky-rgb: 190, 224, 255;
     --support-rose-rgb: 242, 153, 218;
     --support-saffron-rgb: 228, 204, 82;
     --section-label: #bee0ff;
     --section-label-rgb: 190, 224, 255;
+    --value-title-accent: var(--accent-secondary);
+    --value-detail-accent: var(--accent-primary);
+    --value-detail-accent-rgb: var(--accent-primary-rgb);
+    --related-values-accent: #e4cc52;
+    --related-values-accent-rgb: var(--support-saffron-rgb);
+    --value-description-color: var(--text-secondary);
+    --tag-hover-text: var(--background);
+    --tag-selected-text: var(--background);
     --btn-hover: #9bc4ff;
 }
 
@@ -2822,11 +2844,20 @@ body[data-palette="night-garden"] {
     --support-purple: #c587f0;
     --support-amethyst-rgb: 197, 135, 240;
     --support-lavender-rgb: 234, 222, 239;
+    --support-sky: #7faab2;
     --support-sky-rgb: 127, 170, 178;
     --support-rose-rgb: 249, 115, 198;
     --support-saffron-rgb: 205, 207, 75;
     --section-label: #f3ecfb;
     --section-label-rgb: 243, 236, 251;
+    --value-title-accent: var(--accent-primary);
+    --value-detail-accent: var(--accent-secondary);
+    --value-detail-accent-rgb: var(--accent-secondary-rgb);
+    --related-values-accent: var(--accent-primary);
+    --related-values-accent-rgb: var(--accent-primary-rgb);
+    --value-description-color: var(--text-secondary);
+    --tag-hover-text: #20182d;
+    --tag-selected-text: #20182d;
     --btn-hover: #e1bcff;
 }
 

--- a/tests/test_homepage_i18n.py
+++ b/tests/test_homepage_i18n.py
@@ -16,7 +16,7 @@ class HomepageI18nTest(unittest.TestCase):
         )
         self.assertIsNotNone(heading)
         self.assertEqual(heading.group(1), "Browse by category")
-        asset_version = "value-hierarchy-20260713"
+        asset_version = "tag-contrast-20260713"
         self.assertIn(f'href="style.css?v={asset_version}"', html)
         self.assertIn(f'src="script.js?v={asset_version}"', html)
 
@@ -33,15 +33,82 @@ class HomepageI18nTest(unittest.TestCase):
         self.assertIn("--alpha-nav-sticky-offset", script)
         self.assertIn("ResizeObserver", script)
 
-    def test_electric_bloom_separates_value_and_related_accents(self):
+    def test_each_palette_defines_the_value_color_hierarchy(self):
         css = (ROOT / "style.css").read_text(encoding="utf-8")
         script = (ROOT / "script.js").read_text(encoding="utf-8")
 
-        self.assertIn("--value-detail-accent: var(--accent-secondary);", css)
-        self.assertIn("--related-values-accent: var(--accent-primary);", css)
+        palette_expectations = {
+            "hill-country": (
+                "--value-title-accent: var(--support-purple);",
+                "--value-detail-accent: var(--accent-primary);",
+                "--related-values-accent: var(--accent-secondary);",
+            ),
+            "electric-bloom": (
+                "--value-title-accent: var(--accent-secondary);",
+                "--value-detail-accent: var(--accent-secondary);",
+                "--related-values-accent: var(--accent-primary);",
+            ),
+            "blue-hour": (
+                "--value-title-accent: var(--accent-secondary);",
+                "--value-detail-accent: var(--accent-primary);",
+                "--related-values-accent: #e4cc52;",
+            ),
+            "night-garden": (
+                "--value-title-accent: var(--accent-primary);",
+                "--value-detail-accent: var(--accent-secondary);",
+                "--related-values-accent: var(--accent-primary);",
+            ),
+        }
+
+        for palette, declarations in palette_expectations.items():
+            palette_block = re.search(
+                rf'body\[data-palette="{palette}"\]\s*\{{([^}}]+)\}}', css
+            )
+            self.assertIsNotNone(palette_block, palette)
+            for declaration in declarations:
+                self.assertIn(declaration, palette_block.group(1), palette)
+
+        self.assertIn("color: var(--value-title-accent);", css)
+        self.assertIn("background: var(--value-detail-accent);", css)
         self.assertIn("border-left: 5px solid var(--value-detail-accent);", css)
         self.assertIn("border-left: 5px solid var(--related-values-accent);", css)
         self.assertIn("'section-label', 'section-label--related'", script)
+
+    def test_palette_tag_states_use_solid_sky_and_readable_foregrounds(self):
+        css = (ROOT / "style.css").read_text(encoding="utf-8")
+
+        palette_expectations = {
+            "hill-country": (
+                "--support-sky: #d8ddd5;",
+                "--tag-hover-text: var(--header-text);",
+            ),
+            "electric-bloom": (
+                "--support-sky: #9fd9e0;",
+                "--tag-hover-text: var(--header-text);",
+                "--tag-selected-text: var(--header-text);",
+            ),
+            "blue-hour": (
+                "--support-sky: #bee0ff;",
+                "--tag-hover-text: var(--background);",
+                "--tag-selected-text: var(--background);",
+            ),
+            "night-garden": (
+                "--support-sky: #7faab2;",
+                "--tag-hover-text: #20182d;",
+                "--tag-selected-text: #20182d;",
+            ),
+        }
+
+        for palette, declarations in palette_expectations.items():
+            palette_block = re.search(
+                rf'body\[data-palette="{palette}"\]\s*\{{([^}}]+)\}}', css
+            )
+            self.assertIsNotNone(palette_block, palette)
+            for declaration in declarations:
+                self.assertIn(declaration, palette_block.group(1), palette)
+
+        self.assertIn("color: var(--tag-hover-text);", css)
+        self.assertIn("color: var(--tag-selected-text);", css)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- adds four selectable site palettes with palette-specific value-card hierarchy
- syncs the branch with current `main`, including the value-card hierarchy from #158
- adds solid `--support-sky` tokens so tag hover states stay inside each palette
- decouples selected and hovered tag foregrounds from card backgrounds for readable contrast

## Why

Selected Electric Bloom tags inherited a nearly white card token over a light gradient, and hover states fell back to the root sage because the new palettes only supplied RGB sky values. The new semantic tag foreground tokens and paired solid/RGB sky tokens keep both states readable and palette-correct.

## Validation

- `python3 -m unittest discover -s tests -v` (8 tests)
- in-app browser verification of Electric Bloom selected and hover states
- computed Electric Bloom colors: dark ink `rgb(32, 24, 45)`, solid sky `rgb(159, 217, 224)`
- no browser console warnings or errors