### PR TITLE
Clarify value card color hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
     </script>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=sticky-stack-20260713">
+    <link rel="stylesheet" href="style.css?v=value-hierarchy-20260713">
 </head>
 <body>
     <noscript>
@@ -1461,6 +1461,6 @@
         </footer>
     </div>
 
-    <script src="script.js?v=sticky-stack-20260713"></script>
+    <script src="script.js?v=value-hierarchy-20260713"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -3370,11 +3370,11 @@ function displayValues(valuesToDisplay) {
                 const relatedValues = findRelatedValues(value);
                 if (relatedValues.length > 0) {
                     const relatedSection = document.createElement('div');
-                    relatedSection.classList.add('mb-3');
+                    relatedSection.classList.add('mb-3', 'related-values-section');
 
                     const relatedLabel = document.createElement('div');
                     relatedLabel.innerHTML = `<i class="fas fa-link"></i> ${translate('valueCard.relatedValuesLabel')}`;
-                    relatedLabel.classList.add('section-label');
+                    relatedLabel.classList.add('section-label', 'section-label--related');
                     relatedSection.appendChild(relatedLabel);
 
                     const relatedGrid = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -32,6 +32,12 @@
     --dictionary-fade-start: clamp(360px, 42vh, 560px);
     --section-label: #7a6144;
     --section-label-rgb: 122, 97, 68;
+    --value-detail-accent: var(--accent-primary);
+    --value-detail-accent-rgb: var(--accent-primary-rgb);
+    --related-values-accent: var(--accent-secondary);
+    --related-values-accent-rgb: var(--accent-secondary-rgb);
+    --value-title-accent: var(--support-purple);
+    --value-description-color: var(--accent-primary);
     --header-text: #3b4137;
     --dark-text: var(--text-secondary);
     --btn-hover: #425645;
@@ -423,12 +429,12 @@ button, .value-card-toggle, .status-action-button {
 
 .value-card h3 {
     font-size: 1.375rem;
-    color: var(--support-purple);
+    color: var(--value-title-accent);
 }
 
 .value-description {
     font-size: 1.125rem;
-    color: var(--accent-primary);
+    color: var(--value-description-color);
 }
 
 .tag {
@@ -468,6 +474,14 @@ button, .value-card-toggle, .status-action-button {
 .tag.selected:hover,
 .tag.is-selected-verb:hover {
     background: linear-gradient(135deg, rgba(var(--support-amethyst-rgb), 1), rgba(var(--support-sky-rgb), 0.96));
+}
+
+.tag.is-selected-verb,
+.tag.is-selected-verb:hover {
+    background: var(--value-detail-accent);
+    color: var(--card-bg);
+    border-color: rgba(var(--value-detail-accent-rgb), 0.72);
+    box-shadow: 0 6px 16px rgba(var(--value-detail-accent-rgb), 0.2);
 }
 
 .tag:focus-visible {
@@ -948,7 +962,7 @@ button, .value-card-toggle, .status-action-button {
     padding: 1rem;
     margin: 0.75rem 0 1.25rem 0;
     font-style: italic;
-    border-left: 5px solid var(--accent-primary);
+    border-left: 5px solid var(--value-detail-accent);
 }
 
 /* Main search bar */
@@ -1026,7 +1040,7 @@ button, .value-card-toggle, .status-action-button {
     cursor: pointer;
     display: flex;
     flex-direction: column;
-    border-left: 5px solid var(--accent-secondary);
+    border-left: 5px solid var(--related-values-accent);
     position: relative;
     overflow: hidden;
 }
@@ -1051,11 +1065,11 @@ button, .value-card-toggle, .status-action-button {
 }
 
 .shared-tag {
-    background-color: rgba(var(--accent-primary-rgb), 0.1);
-    color: var(--accent-primary);
+    background-color: rgba(var(--related-values-accent-rgb), 0.1);
+    color: var(--related-values-accent);
     padding: 0.125rem 0.375rem;
     border-radius: 4px;
-    border: 1px solid rgba(var(--accent-primary-rgb), 0.3);
+    border: 1px solid rgba(var(--related-values-accent-rgb), 0.3);
 }
 
 .related-tooltip {
@@ -1063,7 +1077,7 @@ button, .value-card-toggle, .status-action-button {
     bottom: 0;
     left: 0;
     right: 0;
-    background: var(--accent-primary);
+    background: var(--related-values-accent);
     color: var(--card-bg);
     padding: 0.5rem;
     transform: translateY(100%);
@@ -2028,14 +2042,14 @@ button, .value-card-toggle, .status-action-button {
 
 .value-card-toggle {
     cursor: pointer;
-    color: var(--accent-primary);
+    color: var(--value-detail-accent);
     font-weight: 500;
     display: flex;
     align-items: center;
     justify-content: center;
     padding: 4px 0;
     margin-top: 8px;
-    border-top: 1px solid rgba(var(--accent-primary-rgb), 0.1);
+    border-top: 1px solid rgba(var(--value-detail-accent-rgb), 0.1);
 }
 
 .value-card-toggle i {
@@ -2058,6 +2072,11 @@ button, .value-card-toggle, .status-action-button {
 
 .section-label i {
     margin-right: 0.5rem;
+}
+
+.section-label--related {
+    color: var(--related-values-accent);
+    border-bottom-color: rgba(var(--related-values-accent-rgb), 0.24);
 }
 
 /* Footer */
@@ -2731,7 +2750,18 @@ body[data-palette="electric-bloom"] {
     --support-saffron-rgb: 185, 223, 207;
     --section-label: #6b4d7e;
     --section-label-rgb: 107, 77, 126;
+    --value-detail-accent: var(--accent-secondary);
+    --value-detail-accent-rgb: var(--accent-secondary-rgb);
+    --related-values-accent: var(--accent-primary);
+    --related-values-accent-rgb: var(--accent-primary-rgb);
+    --value-title-accent: var(--accent-secondary);
+    --value-description-color: var(--text-secondary);
     --btn-hover: #913d36;
+}
+
+body[data-palette="electric-bloom"] .value-card:not(.value-card--gallery) {
+    border-image: none;
+    border-left-color: var(--value-detail-accent);
 }
 
 body[data-palette="blue-hour"] {

--- a/tests/test_homepage_i18n.py
+++ b/tests/test_homepage_i18n.py
@@ -16,7 +16,7 @@ class HomepageI18nTest(unittest.TestCase):
         )
         self.assertIsNotNone(heading)
         self.assertEqual(heading.group(1), "Browse by category")
-        asset_version = "sticky-stack-20260713"
+        asset_version = "value-hierarchy-20260713"
         self.assertIn(f'href="style.css?v={asset_version}"', html)
         self.assertIn(f'src="script.js?v={asset_version}"', html)
 
@@ -32,6 +32,16 @@ class HomepageI18nTest(unittest.TestCase):
         script = (ROOT / "script.js").read_text(encoding="utf-8")
         self.assertIn("--alpha-nav-sticky-offset", script)
         self.assertIn("ResizeObserver", script)
+
+    def test_electric_bloom_separates_value_and_related_accents(self):
+        css = (ROOT / "style.css").read_text(encoding="utf-8")
+        script = (ROOT / "script.js").read_text(encoding="utf-8")
+
+        self.assertIn("--value-detail-accent: var(--accent-secondary);", css)
+        self.assertIn("--related-values-accent: var(--accent-primary);", css)
+        self.assertIn("border-left: 5px solid var(--value-detail-accent);", css)
+        self.assertIn("border-left: 5px solid var(--related-values-accent);", css)
+        self.assertIn("'section-label', 'section-label--related'", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- assign purple to the current value title, controls, example rail, and selected verb in Electric Bloom
- introduce red only for the Related Values heading, card rails, and shared verb tags
- keep the mint and blush card surfaces intact
- add semantic color tokens and a regression test so future palette edits do not reverse the hierarchy
- refresh asset version strings so the matching CSS and JavaScript load together

## Why

The expanded value card used red for the example and purple for related values, which inverted the intended information hierarchy. The previous feature branch was also deleted remotely after its sticky-filter work landed on main, so this change is rebuilt cleanly from current main.

## User impact

The expanded card now reads as one cohesive purple value profile. Red appears only when the content shifts into related values, making the grouping clearer on desktop and mobile. Selected verb chips also use a darker, higher-contrast purple state.

## Validation

- `python3 -m unittest discover -s tests -v` — 7 tests passed
- desktop visual check at the local homepage using Electric Bloom
- mobile visual check at 390 × 844
- verified search → expand Confidence → select “believe” interaction
- verified purple and red computed color roles
- no browser console warnings or errors